### PR TITLE
Update .babelrc for polyfill

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,13 +1,11 @@
 {
   "presets": [
-    "es2015-riot",
-    [
-      "env", {
-        "modules": false,
-        "targets": {
-          "browsers": ["last 2 versions"]
-        }
-      }
-    ]
+    ["env", {
+      "targets": {
+        "browsers": ["last 2 versions", "not ie <= 10", "not android >= 4.4.3"]
+      },
+      "useBuiltIns": true,
+      "modules": false
+    }]
   ]
 }

--- a/client/src/app.js
+++ b/client/src/app.js
@@ -1,6 +1,9 @@
+// polyfill
+import "babel-polyfill";
+import "event-source-polyfill";
+
 import riot from "riot";
 import "font-awesome/scss/font-awesome.scss";
-import "event-source-polyfill";
 import "./styles.scss";
 import "./tags/homo-anime";
 import "./tags/homo-app";

--- a/client/src/tags/homo-content.tag
+++ b/client/src/tags/homo-content.tag
@@ -49,7 +49,6 @@
         }
     </style>
     <script type="es6">
-        import "babel-polyfill";
         import Shuffle from "shufflejs";
 
         this.items = [];

--- a/package-lock.json
+++ b/package-lock.json
@@ -795,7 +795,7 @@
       "dev": true,
       "requires": {
         "babel-runtime": "6.23.0",
-        "core-js": "2.4.1",
+        "core-js": "2.5.0",
         "regenerator-runtime": "0.10.5"
       }
     },
@@ -855,35 +855,6 @@
         }
       }
     },
-    "babel-preset-es2015-riot": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/babel-preset-es2015-riot/-/babel-preset-es2015-riot-1.1.0.tgz",
-      "integrity": "sha1-eBCnTw9fgqzBadtQbUPENaPd/Do=",
-      "dev": true,
-      "requires": {
-        "babel-plugin-check-es2015-constants": "6.22.0",
-        "babel-plugin-transform-es2015-arrow-functions": "6.22.0",
-        "babel-plugin-transform-es2015-block-scoped-functions": "6.22.0",
-        "babel-plugin-transform-es2015-block-scoping": "6.24.1",
-        "babel-plugin-transform-es2015-classes": "6.24.1",
-        "babel-plugin-transform-es2015-computed-properties": "6.24.1",
-        "babel-plugin-transform-es2015-destructuring": "6.23.0",
-        "babel-plugin-transform-es2015-duplicate-keys": "6.24.1",
-        "babel-plugin-transform-es2015-for-of": "6.23.0",
-        "babel-plugin-transform-es2015-function-name": "6.24.1",
-        "babel-plugin-transform-es2015-literals": "6.22.0",
-        "babel-plugin-transform-es2015-modules-commonjs": "6.24.1",
-        "babel-plugin-transform-es2015-object-super": "6.24.1",
-        "babel-plugin-transform-es2015-parameters": "6.24.1",
-        "babel-plugin-transform-es2015-shorthand-properties": "6.24.1",
-        "babel-plugin-transform-es2015-spread": "6.22.0",
-        "babel-plugin-transform-es2015-sticky-regex": "6.24.1",
-        "babel-plugin-transform-es2015-template-literals": "6.22.0",
-        "babel-plugin-transform-es2015-typeof-symbol": "6.23.0",
-        "babel-plugin-transform-es2015-unicode-regex": "6.24.1",
-        "babel-plugin-transform-regenerator": "6.24.1"
-      }
-    },
     "babel-register": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.24.1.tgz",
@@ -892,7 +863,7 @@
       "requires": {
         "babel-core": "6.25.0",
         "babel-runtime": "6.23.0",
-        "core-js": "2.4.1",
+        "core-js": "2.5.0",
         "home-or-tmp": "2.0.0",
         "lodash": "4.17.4",
         "mkdirp": "0.5.1",
@@ -905,7 +876,7 @@
       "integrity": "sha1-CpSJ8UTecO+zzkMArM2zKeL8VDs=",
       "dev": true,
       "requires": {
-        "core-js": "2.4.1",
+        "core-js": "2.5.0",
         "regenerator-runtime": "0.10.5"
       }
     },
@@ -1540,9 +1511,9 @@
       "dev": true
     },
     "core-js": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
-      "integrity": "sha1-TekR5mew6ukSTjQlS1OupvxhjT4=",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.0.tgz",
+      "integrity": "sha1-VpwFCRi+ZIazg3VSAorgRmtxcIY=",
       "dev": true
     },
     "core-util-is": {
@@ -3009,8 +2980,7 @@
         "jsbn": {
           "version": "0.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "json-schema": {
           "version": "0.2.3",
@@ -3427,8 +3397,7 @@
         "tweetnacl": {
           "version": "0.14.5",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "uid-number": {
           "version": "0.0.6",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "babel-loader": "^7.1.1",
     "babel-polyfill": "^6.23.0",
     "babel-preset-env": "^1.6.0",
-    "babel-preset-es2015-riot": "^1.1.0",
     "clean-webpack-plugin": "^0.1.16",
     "css-loader": "^0.28.4",
     "eslint": "^4.4.1",

--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -1,7 +1,7 @@
-import webpack from "webpack";
-import path from "path";
-import CleanWebpackPlugin from "clean-webpack-plugin";
-import HtmlWebpackPlugin from "html-webpack-plugin";
+const webpack = require("webpack");
+const path = require("path");
+const CleanWebpackPlugin = require("clean-webpack-plugin");
+const HtmlWebpackPlugin = require("html-webpack-plugin");
 
 module.exports = {
     entry: "./client/src/app.js",


### PR DESCRIPTION
IE 11 向けに .babelrc を設定し直しました。

* event-source-polyfill が `Object.assign` を使用しているためその前に babel-polyfill を import する
* 使用している core-js が古く、IE 11 でエラーを出していたため最新のものに変更
* .babelrc の変更に伴い webpack.config.babel.js で ES6 Modules が使えなくなったため CommonJS に変更
  * もし ES6 Modules で書きたい場合は .babelrc を webpack.config.babel.js 用にして、ビルド時の Babel の設定を別で用意する必要がある