### PR TITLE
Create client/dist before the Docker container creates it in CI build

### DIFF
--- a/bin/.travis/before_script
+++ b/bin/.travis/before_script
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+mkdir -p client/dist
+
 if [[ "$TRAVIS_BRANCH" = "master" ]] && [[ "$TRAVIS_PULL_REQUEST" = "false" ]]; then
     openssl aes-256-cbc -K $encrypted_ac993ad70486_key -iv $encrypted_ac993ad70486_iv -in bin/.travis/ssh.tar.enc -out ssh.tar -d
     tar xvf ssh.tar


### PR DESCRIPTION
Create `client/dist` so deploy user owns a write permission to that directory. For further information, have a look at #16.