### PR TITLE
Fix volumes config in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     build: ./api
     working_dir: /var/www/html/api
     volumes:
-      - ./api:/var/www/html/api
+      - .:/var/www/html
     networks:
       - default
 


### PR DESCRIPTION
The installation process failed to access `.git` directory and resulted in a build error.