### PR TITLE
Fix a bug where query was exporterd in standard SQL

### DIFF
--- a/api/src/Repository/HomoRepository.php
+++ b/api/src/Repository/HomoRepository.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 namespace HomoChecker\Repository;
 
 use HomoChecker\Contracts\Repository\HomoRepository as HomoRepositoryContract;
-use Illuminate\Database\Query\Grammars\Grammar;
+use Illuminate\Database\Query\Grammars\MySqlGrammar;
 use Illuminate\Support\Facades\DB;
 
 class HomoRepository implements HomoRepositoryContract
@@ -36,7 +36,7 @@ class HomoRepository implements HomoRepositoryContract
         $builder = DB::table($this->table);
 
         // Create a Grammar instance that doesn't parameterize its values
-        $grammar = new class() extends Grammar {
+        $grammar = new class() extends MySqlGrammar {
             /**
              * Only quote the given parameter.
              * @return string

--- a/api/tests/Case/Repository/HomoRepositoryTest.php
+++ b/api/tests/Case/Repository/HomoRepositoryTest.php
@@ -147,10 +147,10 @@ class HomoRepositoryTest extends TestCase
           ->andReturn($builder);
 
         $sql = <<<'SQL'
-        insert into "users" ("screen_name", "service", "url") values ('foo', 'twitter', 'https://foo.example.com/1');
-        insert into "users" ("screen_name", "service", "url") values ('foo', 'twitter', 'https://foo.example.com/2');
-        insert into "users" ("screen_name", "service", "url") values ('bar', 'mastodon', 'http://bar.example.com');
-        insert into "users" ("screen_name", "service", "url") values ('baz', 'mastodon', 'https://baz.example.com');
+        insert into `users` (`screen_name`, `service`, `url`) values ('foo', 'twitter', 'https://foo.example.com/1');
+        insert into `users` (`screen_name`, `service`, `url`) values ('foo', 'twitter', 'https://foo.example.com/2');
+        insert into `users` (`screen_name`, `service`, `url`) values ('bar', 'mastodon', 'http://bar.example.com');
+        insert into `users` (`screen_name`, `service`, `url`) values ('baz', 'mastodon', 'https://baz.example.com');
         SQL;
 
         $homo = new HomoRepository();


### PR DESCRIPTION
MySQL doesn't understand table/column names quoted by `"`.