### PR TITLE
Fix routing and errorHandler for /check, /list, and /badge

### DIFF
--- a/api/src/Action/CheckAction.php
+++ b/api/src/Action/CheckAction.php
@@ -9,6 +9,7 @@ use HomoChecker\Domain\Status;
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
 use Psr\Http\Message\StreamInterface;
+use Slim\Http\Response as HttpResponse;
 
 class CheckAction
 {
@@ -40,6 +41,7 @@ class CheckAction
 
     protected function byJSON(Response $response, string $screen_name = null): Response
     {
+        /** @var HttpResponse $response */
         $result = $this->check->execute($screen_name);
         return $response->withJson($result, !empty($result) ? 200 : 404);
     }

--- a/api/src/Action/ListAction.php
+++ b/api/src/Action/ListAction.php
@@ -20,12 +20,14 @@ class ListAction
 
     public function __invoke(Request $request, Response $response, array $args)
     {
+        $screen_name = $args['name'] ?? null;
+
         switch ($request->getQueryParams()['format'] ?? 'json') {
             case 'sql': {
                 return $response->withHeader('Content-Type', 'application/sql')->withBody($this->createSql($response));
             }
             default: {
-                $users = $this->homo->find();
+                $users = $this->homo->find($screen_name);
                 return $response->withJson($this->createArray($users), !empty($users) ? 200 : 404);
             }
         }

--- a/api/src/Providers/HomoAppProvider.php
+++ b/api/src/Providers/HomoAppProvider.php
@@ -26,6 +26,7 @@ class HomoAppProvider extends ServiceProvider
         $this->app->singleton('app', function (Container $app) {
             AppFactory::setContainer($app);
             $slim = AppFactory::create();
+            $slim->addErrorMiddleware(true, true, true)->setDefaultErrorHandler($app->make('errorHandler'));
             $slim->get('/check[/[{name}[/]]]', CheckAction::class);
             $slim->get('/list[/[{name}[/]]]', ListAction::class);
             $slim->get('/badge[/[{status}[/]]]', BadgeAction::class);

--- a/api/src/Providers/HomoAppProvider.php
+++ b/api/src/Providers/HomoAppProvider.php
@@ -12,7 +12,6 @@ use Illuminate\Config\Repository;
 use Illuminate\Contracts\Container\Container;
 use Illuminate\Support\ServiceProvider;
 use Slim\Factory\AppFactory;
-use Slim\Router;
 
 class HomoAppProvider extends ServiceProvider
 {
@@ -27,17 +26,15 @@ class HomoAppProvider extends ServiceProvider
         $this->app->singleton('app', function (Container $app) {
             AppFactory::setContainer($app);
             $slim = AppFactory::create();
-            $slim->get('/check/[{name}/]', CheckAction::class);
-            $slim->get('/list/[{name}/]', ListAction::class);
-            $slim->get('/badge/[{status}/]', BadgeAction::class);
+            $slim->get('/check[/[{name}[/]]]', CheckAction::class);
+            $slim->get('/list[/[{name}[/]]]', ListAction::class);
+            $slim->get('/badge[/[{status}[/]]]', BadgeAction::class);
             return $slim;
         });
 
         $this->app->singleton('config', function (Container $app) {
             return new Repository($app->make('settings'));
         });
-
-        $this->app->singleton('router', Router::class);
     }
 
     public function provides()
@@ -48,7 +45,6 @@ class HomoAppProvider extends ServiceProvider
             BadgeAction::class,
             'app',
             'config',
-            'router',
         ];
     }
 }

--- a/api/src/Providers/HomoHandlerProvider.php
+++ b/api/src/Providers/HomoHandlerProvider.php
@@ -3,26 +3,32 @@ declare(strict_types=1);
 
 namespace HomoChecker\Providers;
 
+use Illuminate\Contracts\Container\Container;
 use Illuminate\Support\ServiceProvider;
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
+use Slim\App;
+use Slim\Exception\HttpInternalServerErrorException;
+use Slim\Exception\HttpSpecializedException;
+use Slim\Http\Response as HttpResponse;
+use Throwable;
 
 class HomoHandlerProvider extends ServiceProvider
 {
     public function register()
     {
-        $this->app->singleton('errorHandler', $this->createErrorHandler(500));
-        $this->app->singleton('phpErrorHandler', $this->createErrorHandler(500));
-        $this->app->singleton('notFoundHandler', $this->createErrorHandler(404));
-        $this->app->singleton('notAllowedHandler', $this->createErrorHandler(403));
-    }
+        $this->app->singleton('errorHandler', function (Container $app) {
+            return function (Request $request, Throwable $exception) use ($app): Response {
+                /** @var App $slim */
+                $slim = $app->make('app');
+                error_log((string) $exception);
 
-    protected function createErrorHandler(int $code)
-    {
-        return function () use ($code): callable {
-            return function (Request $request, Response $response, $e = null) use ($code): Response {
-                error_log((string) $e);
-                $response = $response->withStatus($code);
+                if (!$exception instanceof HttpSpecializedException) {
+                    $exception = new HttpInternalServerErrorException($request, $exception->getMessage());
+                }
+
+                /** @var HttpResponse $response */
+                $response = $slim->getResponseFactory()->createResponse($exception->getCode());
                 return $response->withJson([
                     'errors' => [
                         'code' => $response->getStatusCode(),
@@ -30,16 +36,13 @@ class HomoHandlerProvider extends ServiceProvider
                     ],
                 ]);
             };
-        };
+        });
     }
 
     public function provides()
     {
         return [
             'errorHandler',
-            'phpErrorHandler',
-            'notFoundHandler',
-            'notAllowedHandler',
         ];
     }
 }

--- a/api/src/Providers/HomoHandlerProvider.php
+++ b/api/src/Providers/HomoHandlerProvider.php
@@ -21,9 +21,9 @@ class HomoHandlerProvider extends ServiceProvider
             return function (Request $request, Throwable $exception) use ($app): Response {
                 /** @var App $slim */
                 $slim = $app->make('app');
-                error_log((string) $exception);
 
                 if (!$exception instanceof HttpSpecializedException) {
+                    error_log((string) $exception);
                     $exception = new HttpInternalServerErrorException($request, $exception->getMessage());
                 }
 

--- a/api/src/Providers/HomoProvider.php
+++ b/api/src/Providers/HomoProvider.php
@@ -57,7 +57,6 @@ class HomoProvider extends ServiceProvider
             CacheServiceContract::class,
             CheckServiceContract::class,
             HomoServiceContract::class,
-            HomoRepositoryContract::class,
         ];
     }
 }

--- a/api/tests/Case/Action/ListActionTest.php
+++ b/api/tests/Case/Action/ListActionTest.php
@@ -44,6 +44,7 @@ class ListActionTest extends TestCase
         /** @var HomoService|MockInterface $homo */
         $homo = m::mock(HomoService::class);
         $homo->shouldReceive('find')
+             ->with(null)
              ->andReturn($this->users);
 
         $action = new ListAction($homo);


### PR DESCRIPTION
Fixes errorHandler that has been changed and updates each route to accept path with and without trailing slashe like `/check` and `/check/`.