### PR TITLE
Disable keepalive in client container

### DIFF
--- a/client/conf/default.conf
+++ b/client/conf/default.conf
@@ -7,6 +7,7 @@ charset utf-8;
 server {
     listen 80 default;
     server_name _;
+    keepalive_timeout 0;
 
     location @api {
         include fastcgi_params;


### PR DESCRIPTION
Backend servers do not have to keepalive their connection because it would be inconsistent with client requests.