### PR TITLE
Fix assertions to handle deprecation warnings

### DIFF
--- a/api/tests/Case/Action/BadgeActionTest.php
+++ b/api/tests/Case/Action/BadgeActionTest.php
@@ -86,8 +86,8 @@ class BadgeActionTest extends TestCase
 
         $response = $action($request, new HttpResponse(new Response(), new StreamFactory()), []);
         $actual = $response->getHeaderLine('Location');
-        $this->assertRegExp('|^https?://img\.shields\.io/badge/.*\.svg|', $actual);
-        $this->assertRegExp('/3(?: |%20|\+)registered/', $actual);
+        $this->assertMatchesRegularExpression('|^https?://img\.shields\.io/badge/.*\.svg|', $actual);
+        $this->assertMatchesRegularExpression('/3(?: |%20|\+)registered/', $actual);
     }
 
     public function testStatusCount(): void
@@ -105,8 +105,8 @@ class BadgeActionTest extends TestCase
 
         $response = $action($request, new HttpResponse(new Response(), new StreamFactory()), ['status' => 'OK']);
         $actual = $response->getHeaderLine('Location');
-        $this->assertRegExp('|^https?://img\.shields\.io/badge/.*\.svg|', $actual);
-        $this->assertRegExp('/2(?: |%20|\+)ok/', $actual);
+        $this->assertMatchesRegularExpression('|^https?://img\.shields\.io/badge/.*\.svg|', $actual);
+        $this->assertMatchesRegularExpression('/2(?: |%20|\+)ok/', $actual);
     }
 
     public function testParams(): void
@@ -124,7 +124,7 @@ class BadgeActionTest extends TestCase
 
         $response = $action($request, new HttpResponse(new Response(), new StreamFactory()), []);
         $actual = $response->getHeaderLine('Location');
-        $this->assertRegExp('|^https?://img\.shields\.io/badge/.*\.svg|', $actual);
+        $this->assertMatchesRegularExpression('|^https?://img\.shields\.io/badge/.*\.svg|', $actual);
         $this->assertStringEndsWith('?style=flat-square', $actual);
     }
 }

--- a/api/tests/Case/Action/CheckActionTest.php
+++ b/api/tests/Case/Action/CheckActionTest.php
@@ -100,7 +100,7 @@ class CheckActionTest extends TestCase
         $action = new CheckAction($check, $homo, $stream);
         $response = $action($request, new HttpResponse(new Response(), new StreamFactory()), []);
         $actual = $response->getHeaderLine('Content-Type');
-        $this->assertRegExp('|^application/json|', $actual);
+        $this->assertMatchesRegularExpression('|^application/json|', $actual);
 
         $actual = (string) $response->getBody();
         $expected = json_encode([

--- a/api/tests/Case/Action/ListActionTest.php
+++ b/api/tests/Case/Action/ListActionTest.php
@@ -52,7 +52,7 @@ class ListActionTest extends TestCase
 
         $response = $action($request, new HttpResponse(new Response(), new StreamFactory()), []);
         $actual = $response->getHeaderLine('Content-Type');
-        $this->assertRegExp('|^application/json|', $actual);
+        $this->assertMatchesRegularExpression('|^application/json|', $actual);
 
         $actual = (string) $response->getBody();
         $users = [
@@ -101,7 +101,7 @@ class ListActionTest extends TestCase
 
         $response = $action($request, new HttpResponse(new Response(), new StreamFactory()), []);
         $actual = $response->getHeaderLine('Content-Type');
-        $this->assertRegExp('|^application/sql|', $actual);
+        $this->assertMatchesRegularExpression('|^application/sql|', $actual);
 
         $actual = (string) $response->getBody();
         $this->assertEquals($sql, $actual);


### PR DESCRIPTION
PHPUnit 9 deprecates `assertRegExp` and PHPUnit 10 will replace it with `assertMatchesRegularExpression `.