### PR TITLE
Improve logging in api

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -12,4 +12,7 @@ RUN apk add --no-cache --virtual build-dependencies \
     docker-php-ext-install pdo_mysql && \
     apk del build-dependencies
 
+RUN echo 'display_errors = 0' > /usr/local/etc/php/conf.d/overrides.ini
+RUN sed -i 's/^access\.log/; \0/' /usr/local/etc/php-fpm.d/docker.conf
+
 EXPOSE 9000

--- a/api/Dockerfile.development
+++ b/api/Dockerfile.development
@@ -9,4 +9,7 @@ RUN curl -sSfL 'https://raw.githubusercontent.com/composer/getcomposer.org/maste
     docker-php-ext-enable redis && \
     docker-php-ext-install pdo_mysql
 
+RUN echo 'display_errors = 0' > /usr/local/etc/php/conf.d/overrides.ini
+RUN sed -i 's/^access\.log/; \0/' /usr/local/etc/php-fpm.d/docker.conf
+
 RUN echo 'label ::1/128 0' > /etc/gai.conf

--- a/api/composer.json
+++ b/api/composer.json
@@ -6,8 +6,11 @@
         "illuminate/config": "^7.28",
         "illuminate/container": "^7.28",
         "illuminate/database": "^7.28",
+        "illuminate/events": "^7.28",
+        "illuminate/log": "^7.28",
         "illuminate/redis": "^7.28",
         "illuminate/support": "^7.28",
+        "middlewares/access-log": "^1.2",
         "phpoption/phpoption": "^1.7",
         "slim/http": "^1.0",
         "slim/psr7": "^1.2.0",
@@ -38,6 +41,9 @@
         "fix": "php-cs-fixer fix",
         "post-install-cmd": "[ \"$COMPOSER_DEV_MODE\" = 0 ] || cghooks add --ignore-lock",
         "post-update-cmd": "[ \"$COMPOSER_DEV_MODE\" = 0 ] || cghooks update"
+    },
+    "config": {
+        "sort-packages": true
     },
     "extra": {
         "hooks": {

--- a/api/composer.json
+++ b/api/composer.json
@@ -13,7 +13,7 @@
         "slim/psr7": "^1.2.0",
         "slim/slim": "^4.5",
         "true/punycode": "~2.0",
-        "vlucas/phpdotenv": "^5.2"
+        "vlucas/phpdotenv": "^4.1"
     },
     "require-dev": {
         "brainmaestro/composer-git-hooks": "^2.8",

--- a/api/composer.lock
+++ b/api/composer.lock
@@ -150,68 +150,6 @@
             "time": "2020-02-05T20:36:27+00:00"
         },
         {
-            "name": "graham-campbell/result-type",
-            "version": "v1.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/GrahamCampbell/Result-Type.git",
-                "reference": "7e279d2cd5d7fbb156ce46daada972355cea27bb"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/GrahamCampbell/Result-Type/zipball/7e279d2cd5d7fbb156ce46daada972355cea27bb",
-                "reference": "7e279d2cd5d7fbb156ce46daada972355cea27bb",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.0|^8.0",
-                "phpoption/phpoption": "^1.7.3"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^6.5|^7.5|^8.5|^9.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "GrahamCampbell\\ResultType\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Graham Campbell",
-                    "email": "graham@alt-three.com"
-                }
-            ],
-            "description": "An Implementation Of The Result Type",
-            "keywords": [
-                "Graham Campbell",
-                "GrahamCampbell",
-                "Result Type",
-                "Result-Type",
-                "result"
-            ],
-            "funding": [
-                {
-                    "url": "https://github.com/GrahamCampbell",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/graham-campbell/result-type",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2020-04-13T13:17:36+00:00"
-        },
-        {
             "name": "guzzlehttp/guzzle",
             "version": "6.5.5",
             "source": {
@@ -2741,39 +2679,37 @@
         },
         {
             "name": "vlucas/phpdotenv",
-            "version": "v5.2.0",
+            "version": "v4.1.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/vlucas/phpdotenv.git",
-                "reference": "fba64139db67123c7a57072e5f8d3db10d160b66"
+                "reference": "572af79d913627a9d70374d27a6f5d689a35de32"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/vlucas/phpdotenv/zipball/fba64139db67123c7a57072e5f8d3db10d160b66",
-                "reference": "fba64139db67123c7a57072e5f8d3db10d160b66",
+                "url": "https://api.github.com/repos/vlucas/phpdotenv/zipball/572af79d913627a9d70374d27a6f5d689a35de32",
+                "reference": "572af79d913627a9d70374d27a6f5d689a35de32",
                 "shasum": ""
             },
             "require": {
-                "ext-pcre": "*",
-                "graham-campbell/result-type": "^1.0.1",
-                "php": "^7.1.3 || ^8.0",
-                "phpoption/phpoption": "^1.7.4",
-                "symfony/polyfill-ctype": "^1.17",
-                "symfony/polyfill-mbstring": "^1.17",
-                "symfony/polyfill-php80": "^1.17"
+                "php": "^5.5.9 || ^7.0 || ^8.0",
+                "phpoption/phpoption": "^1.7.3",
+                "symfony/polyfill-ctype": "^1.17"
             },
             "require-dev": {
                 "bamarni/composer-bin-plugin": "^1.4.1",
                 "ext-filter": "*",
-                "phpunit/phpunit": "^7.5.20 || ^8.5.2 || ^9.0"
+                "ext-pcre": "*",
+                "phpunit/phpunit": "^4.8.35 || ^5.7.27 || ^6.5.6 || ^7.0"
             },
             "suggest": {
-                "ext-filter": "Required to use the boolean validator."
+                "ext-filter": "Required to use the boolean validator.",
+                "ext-pcre": "Required to use most of the library."
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "5.2-dev"
+                    "dev-master": "4.1-dev"
                 }
             },
             "autoload": {
@@ -2813,7 +2749,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-09-14T15:57:31+00:00"
+            "time": "2020-07-14T19:22:52+00:00"
         },
         {
             "name": "voku/portable-ascii",
@@ -3386,6 +3322,68 @@
                 }
             ],
             "time": "2020-06-27T23:57:46+00:00"
+        },
+        {
+            "name": "graham-campbell/result-type",
+            "version": "v1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/GrahamCampbell/Result-Type.git",
+                "reference": "7e279d2cd5d7fbb156ce46daada972355cea27bb"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/GrahamCampbell/Result-Type/zipball/7e279d2cd5d7fbb156ce46daada972355cea27bb",
+                "reference": "7e279d2cd5d7fbb156ce46daada972355cea27bb",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0|^8.0",
+                "phpoption/phpoption": "^1.7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^6.5|^7.5|^8.5|^9.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "GrahamCampbell\\ResultType\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Graham Campbell",
+                    "email": "graham@alt-three.com"
+                }
+            ],
+            "description": "An Implementation Of The Result Type",
+            "keywords": [
+                "Graham Campbell",
+                "GrahamCampbell",
+                "Result Type",
+                "Result-Type",
+                "result"
+            ],
+            "funding": [
+                {
+                    "url": "https://github.com/GrahamCampbell",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/graham-campbell/result-type",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-04-13T13:17:36+00:00"
         },
         {
             "name": "hamcrest/hamcrest-php",

--- a/api/composer.lock
+++ b/api/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "cb6999aa9a5b6a9663d849eea25a3559",
+    "content-hash": "3fc1331b82e83e065f4796497996f351",
     "packages": [
         {
             "name": "doctrine/inflector",
@@ -638,6 +638,96 @@
             "time": "2020-09-08T11:21:46+00:00"
         },
         {
+            "name": "illuminate/events",
+            "version": "v7.28.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/illuminate/events.git",
+                "reference": "cd6170a6ef48d284a66429a786ce45575abc9c6b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/illuminate/events/zipball/cd6170a6ef48d284a66429a786ce45575abc9c6b",
+                "reference": "cd6170a6ef48d284a66429a786ce45575abc9c6b",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/container": "^7.0",
+                "illuminate/contracts": "^7.0",
+                "illuminate/support": "^7.0",
+                "php": "^7.2.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "7.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Illuminate\\Events\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Taylor Otwell",
+                    "email": "taylor@laravel.com"
+                }
+            ],
+            "description": "The Illuminate Events package.",
+            "homepage": "https://laravel.com",
+            "time": "2020-08-24T13:15:53+00:00"
+        },
+        {
+            "name": "illuminate/log",
+            "version": "v7.28.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/illuminate/log.git",
+                "reference": "603737e002313762020371e956dc47c6aa2f15aa"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/illuminate/log/zipball/603737e002313762020371e956dc47c6aa2f15aa",
+                "reference": "603737e002313762020371e956dc47c6aa2f15aa",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/contracts": "^7.0",
+                "illuminate/support": "^7.0",
+                "monolog/monolog": "^2.0",
+                "php": "^7.2.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "7.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Illuminate\\Log\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Taylor Otwell",
+                    "email": "taylor@laravel.com"
+                }
+            ],
+            "description": "The Illuminate Log package.",
+            "homepage": "https://laravel.com",
+            "time": "2020-08-24T13:15:53+00:00"
+        },
+        {
             "name": "illuminate/redis",
             "version": "v7.28.3",
             "source": {
@@ -746,6 +836,149 @@
             "description": "The Illuminate Support package.",
             "homepage": "https://laravel.com",
             "time": "2020-08-28T14:23:23+00:00"
+        },
+        {
+            "name": "middlewares/access-log",
+            "version": "v1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/middlewares/access-log.git",
+                "reference": "c7ba832391bee7bf4df8c37a38b54c3231d4ee4e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/middlewares/access-log/zipball/c7ba832391bee7bf4df8c37a38b54c3231d4ee4e",
+                "reference": "c7ba832391bee7bf4df8c37a38b54c3231d4ee4e",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0",
+                "psr/http-server-middleware": "^1.0",
+                "psr/log-implementation": "^1.0"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^2.0",
+                "middlewares/utils": "^2.1",
+                "monolog/monolog": "^1.21",
+                "phpstan/phpstan": "^0.9.2|^0.10.3",
+                "phpunit/phpunit": "^6.0|^7.0",
+                "squizlabs/php_codesniffer": "^3.0",
+                "zendframework/zend-diactoros": "^1.3"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Middlewares\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Middleware to generate access logs",
+            "homepage": "https://github.com/middlewares/access-log",
+            "keywords": [
+                "access",
+                "http",
+                "logger",
+                "logging",
+                "middleware",
+                "psr-15",
+                "psr-7",
+                "server"
+            ],
+            "time": "2019-02-28T13:08:27+00:00"
+        },
+        {
+            "name": "monolog/monolog",
+            "version": "2.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Seldaek/monolog.git",
+                "reference": "f9eee5cec93dfb313a38b6b288741e84e53f02d5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Seldaek/monolog/zipball/f9eee5cec93dfb313a38b6b288741e84e53f02d5",
+                "reference": "f9eee5cec93dfb313a38b6b288741e84e53f02d5",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2",
+                "psr/log": "^1.0.1"
+            },
+            "provide": {
+                "psr/log-implementation": "1.0.0"
+            },
+            "require-dev": {
+                "aws/aws-sdk-php": "^2.4.9 || ^3.0",
+                "doctrine/couchdb": "~1.0@dev",
+                "elasticsearch/elasticsearch": "^6.0",
+                "graylog2/gelf-php": "^1.4.2",
+                "php-amqplib/php-amqplib": "~2.4",
+                "php-console/php-console": "^3.1.3",
+                "php-parallel-lint/php-parallel-lint": "^1.0",
+                "phpspec/prophecy": "^1.6.1",
+                "phpunit/phpunit": "^8.5",
+                "predis/predis": "^1.1",
+                "rollbar/rollbar": "^1.3",
+                "ruflin/elastica": ">=0.90 <3.0",
+                "swiftmailer/swiftmailer": "^5.3|^6.0"
+            },
+            "suggest": {
+                "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
+                "doctrine/couchdb": "Allow sending log messages to a CouchDB server",
+                "elasticsearch/elasticsearch": "Allow sending log messages to an Elasticsearch server via official client",
+                "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
+                "ext-mbstring": "Allow to work properly with unicode symbols",
+                "ext-mongodb": "Allow sending log messages to a MongoDB server (via driver)",
+                "graylog2/gelf-php": "Allow sending log messages to a GrayLog2 server",
+                "mongodb/mongodb": "Allow sending log messages to a MongoDB server (via library)",
+                "php-amqplib/php-amqplib": "Allow sending log messages to an AMQP server using php-amqplib",
+                "php-console/php-console": "Allow sending log messages to Google Chrome",
+                "rollbar/rollbar": "Allow sending log messages to Rollbar",
+                "ruflin/elastica": "Allow sending log messages to an Elastic Search server"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Monolog\\": "src/Monolog"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "http://seld.be"
+                }
+            ],
+            "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
+            "homepage": "http://github.com/Seldaek/monolog",
+            "keywords": [
+                "log",
+                "logging",
+                "psr-3"
+            ],
+            "funding": [
+                {
+                    "url": "https://github.com/Seldaek",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/monolog/monolog",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-07-23T08:41:23+00:00"
         },
         {
             "name": "nesbot/carbon",

--- a/api/src/Action/HealthCheckAction.php
+++ b/api/src/Action/HealthCheckAction.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace HomoChecker\Action;
 
 use HomoChecker\Contracts\Service\HomoService;
+use Illuminate\Support\Facades\Log;
 use Slim\Http\Response;
 use Slim\Http\ServerRequest as Request;
 
@@ -22,7 +23,7 @@ class HealthCheckAction
             $this->homo->count();
             return $response->withHeader('Content-Type', 'text/plain')->withStatus(200)->write('OK');
         } catch (\Throwable $e) {
-            // TODO: Log using illuminate/log
+            Log::error($e->getMessage());
             return $response->withHeader('Content-Type', 'text/plain')->withStatus(500)->write('Internal Server Error');
         }
     }

--- a/api/src/Action/HealthCheckAction.php
+++ b/api/src/Action/HealthCheckAction.php
@@ -23,7 +23,7 @@ class HealthCheckAction
             $this->homo->count();
             return $response->withHeader('Content-Type', 'text/plain')->withStatus(200)->write('OK');
         } catch (\Throwable $e) {
-            Log::error($e->getMessage());
+            Log::error($e);
             return $response->withHeader('Content-Type', 'text/plain')->withStatus(500)->write('Internal Server Error');
         }
     }

--- a/api/src/Logging/CustomizeFormatter.php
+++ b/api/src/Logging/CustomizeFormatter.php
@@ -1,0 +1,21 @@
+<?php
+declare(strict_types=1);
+
+namespace HomoChecker\Logging;
+
+use Illuminate\Log\Logger;
+use Monolog\Formatter\LineFormatter;
+
+class CustomizeFormatter
+{
+    protected $dateFormat = 'Y-m-d H:i:s';
+
+    public function __invoke(Logger $logger, ?string $format = null)
+    {
+        /** @var \Monolog\Logger $logger */
+        foreach ($logger->getHandlers() as $handler) {
+            /** @var \Monolog\Handler\HandlerWrapper $handler */
+            $handler->setFormatter(new LineFormatter($format, $this->dateFormat, true, true));
+        }
+    }
+}

--- a/api/src/Providers/HomoAppProvider.php
+++ b/api/src/Providers/HomoAppProvider.php
@@ -12,6 +12,7 @@ use HomoChecker\Repository\HomoRepository;
 use Illuminate\Config\Repository;
 use Illuminate\Contracts\Container\Container;
 use Illuminate\Support\ServiceProvider;
+use Middlewares\AccessLog;
 use Slim\Factory\AppFactory;
 
 class HomoAppProvider extends ServiceProvider
@@ -28,6 +29,7 @@ class HomoAppProvider extends ServiceProvider
         $this->app->singleton('app', function (Container $app) {
             AppFactory::setContainer($app);
             $slim = AppFactory::create();
+            $slim->addMiddleware($app->make(AccessLog::class));
             $slim->addErrorMiddleware(true, true, true)->setDefaultErrorHandler($app->make('errorHandler'));
             $slim->get('/healthz', HealthCheckAction::class);
             $slim->get('/check[/[{name}[/]]]', CheckAction::class);

--- a/api/src/Providers/HomoHandlerProvider.php
+++ b/api/src/Providers/HomoHandlerProvider.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace HomoChecker\Providers;
 
 use Illuminate\Contracts\Container\Container;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\ServiceProvider;
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
@@ -23,7 +24,7 @@ class HomoHandlerProvider extends ServiceProvider
                 $slim = $app->make('app');
 
                 if (!$exception instanceof HttpSpecializedException) {
-                    error_log((string) $exception);
+                    Log::error($exception);
                     $exception = new HttpInternalServerErrorException($request, $exception->getMessage());
                 }
 

--- a/api/src/config.php
+++ b/api/src/config.php
@@ -1,6 +1,8 @@
 <?php
 declare(strict_types=1);
 
+use HomoChecker\Logging\CustomizeFormatter;
+
 return [
     'cache.default' => 'default',
     'cache.stores.default' => [
@@ -23,6 +25,22 @@ return [
             'host' => env('HOMOCHECKER_REDIS_HOST'),
             'port' => (int) env('HOMOCHECKER_REDIS_PORT', 6379),
         ],
+    ],
+    'logging.default' => 'default',
+    'logging.channels.default' => [
+        'driver' => 'single',
+        'tap' => [CustomizeFormatter::class . ":[%datetime%] %level_name%: %message% %context% %extra%\n"],
+        'path' => 'php://stderr',
+        'level' => 'info',
+    ],
+    'logging.channels.router' => [
+        'driver' => 'single',
+        'tap' => [CustomizeFormatter::class . ":%message% %context% %extra%\n"],
+        'path' => 'php://stderr',
+        'level' => 'info',
+    ],
+    'logging.channels.emergency' => [
+        'path' => 'php://stderr',
     ],
     'client' => [
         'timeout' => 5,

--- a/api/tests/Case/Action/HealthCheckActionTest.php
+++ b/api/tests/Case/Action/HealthCheckActionTest.php
@@ -53,11 +53,11 @@ class HealthCheckActionTest extends TestCase
         /** @var HomoService|MockInterface $homo */
         $homo = m::mock(HomoService::class);
         $homo->shouldReceive('count')
-             ->andThrow(new Exception('Internal Server Error'));
+             ->andThrow($e = new Exception('Internal Server Error'));
 
         Log::shouldReceive('error')
             ->once()
-            ->with('Internal Server Error');
+            ->with($e);
 
         $action = new HealthCheckAction($homo);
         $request = (new RequestFactory())->createRequest('GET', '/healthz');

--- a/api/tests/Case/Action/HealthCheckActionTest.php
+++ b/api/tests/Case/Action/HealthCheckActionTest.php
@@ -6,6 +6,8 @@ namespace HomoChecker\Test\Action;
 use Exception;
 use HomoChecker\Action\HealthCheckAction;
 use HomoChecker\Contracts\Service\HomoService;
+use Illuminate\Support\Facades\Facade;
+use Illuminate\Support\Facades\Log;
 use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 use Mockery as m;
 use Mockery\MockInterface;
@@ -19,6 +21,11 @@ use Slim\Psr7\Response;
 class HealthCheckActionTest extends TestCase
 {
     use MockeryPHPUnitIntegration;
+
+    public function setUp(): void
+    {
+        Facade::clearResolvedInstances();
+    }
 
     public function testOK(): void
     {
@@ -47,6 +54,10 @@ class HealthCheckActionTest extends TestCase
         $homo = m::mock(HomoService::class);
         $homo->shouldReceive('count')
              ->andThrow(new Exception('Internal Server Error'));
+
+        Log::shouldReceive('error')
+            ->once()
+            ->with('Internal Server Error');
 
         $action = new HealthCheckAction($homo);
         $request = (new RequestFactory())->createRequest('GET', '/healthz');


### PR DESCRIPTION
Application logs and router logs have been improved using Monolog (illuminate/log).

Health check failures now logs stacktraces like the following:

```
[2020-09-20 14:19:20] ERROR: PDOException: PDO::__construct(): php_network_getaddresses: getaddrinfo failed: Name or service not known in /var/www/html/api/vendor/illuminate/database/Connectors/Connector.php:70
Stack trace:
#0 /var/www/html/api/vendor/illuminate/database/Connectors/Connector.php(70): PDO->__construct('mysql:host=data...', 'homo', 'homo', Array)
#1 /var/www/html/api/vendor/illuminate/database/Connectors/Connector.php(46): Illuminate\Database\Connectors\Connector->createPdoConnection('mysql:host=data...', 'homo', 'homo', Array)
#2 /var/www/html/api/vendor/illuminate/database/Connectors/MySqlConnector.php(24): Illuminate\Database\Connectors\Connector->createConnection('mysql:host=data...', Array, Array)
#3 /var/www/html/api/vendor/illuminate/database/Connectors/ConnectionFactory.php(184): Illuminate\Database\Connectors\MySqlConnector->connect(Array)
#4 [internal function]: Illuminate\Database\Connectors\ConnectionFactory->Illuminate\Database\Connectors\{closure}()
#5 /var/www/html/api/vendor/illuminate/database/Connection.php(926): call_user_func(Object(Closure))
#6 /var/www/html/api/vendor/illuminate/database/Connection.php(961): Illuminate\Database\Connection->getPdo()
#7 /var/www/html/api/vendor/illuminate/database/Connection.php(405): Illuminate\Database\Connection->getReadPdo()
#8 /var/www/html/api/vendor/illuminate/database/Connection.php(331): Illuminate\Database\Connection->getPdoForSelect(true)
#9 /var/www/html/api/vendor/illuminate/database/Connection.php(664): Illuminate\Database\Connection->Illuminate\Database\{closure}('select count(*)...', Array)
#10 /var/www/html/api/vendor/illuminate/database/Connection.php(631): Illuminate\Database\Connection->runQueryCallback('select count(*)...', Array, Object(Closure))
#11 /var/www/html/api/vendor/illuminate/database/Connection.php(339): Illuminate\Database\Connection->run('select count(*)...', Array, Object(Closure))
#12 /var/www/html/api/vendor/illuminate/database/Query/Builder.php(2260): Illuminate\Database\Connection->select('select count(*)...', Array, true)
#13 /var/www/html/api/vendor/illuminate/database/Query/Builder.php(2248): Illuminate\Database\Query\Builder->runSelect()
#14 /var/www/html/api/vendor/illuminate/database/Query/Builder.php(2743): Illuminate\Database\Query\Builder->Illuminate\Database\Query\{closure}()
#15 /var/www/html/api/vendor/illuminate/database/Query/Builder.php(2249): Illuminate\Database\Query\Builder->onceWithColumns(Array, Object(Closure))
#16 /var/www/html/api/vendor/illuminate/database/Query/Builder.php(2670): Illuminate\Database\Query\Builder->get(Array)
#17 /var/www/html/api/vendor/illuminate/database/Query/Builder.php(2598): Illuminate\Database\Query\Builder->aggregate('count', Array)
#18 /var/www/html/api/src/Repository/HomoRepository.php(16): Illuminate\Database\Query\Builder->count()
#19 /var/www/html/api/src/Service/HomoService.php(21): HomoChecker\Repository\HomoRepository->count()
#20 /var/www/html/api/src/Action/HealthCheckAction.php(24): HomoChecker\Service\HomoService->count()
#21 /var/www/html/api/vendor/slim/slim/Slim/Handlers/Strategies/RequestResponse.php(43): HomoChecker\Action\HealthCheckAction->__invoke(Object(Slim\Http\ServerRequest), Object(Slim\Http\Response), Array)
#22 /var/www/html/api/vendor/slim/slim/Slim/Routing/Route.php(381): Slim\Handlers\Strategies\RequestResponse->__invoke(Array, Object(Slim\Http\ServerRequest), Object(Slim\Http\Response), Array)
#23 /var/www/html/api/vendor/slim/slim/Slim/MiddlewareDispatcher.php(81): Slim\Routing\Route->handle(Object(Slim\Http\ServerRequest))
#24 /var/www/html/api/vendor/slim/slim/Slim/MiddlewareDispatcher.php(81): Slim\MiddlewareDispatcher->handle(Object(Slim\Http\ServerRequest))
#25 /var/www/html/api/vendor/slim/slim/Slim/Routing/Route.php(341): Slim\MiddlewareDispatcher->handle(Object(Slim\Http\ServerRequest))
#26 /var/www/html/api/vendor/slim/slim/Slim/Routing/RouteRunner.php(84): Slim\Routing\Route->run(Object(Slim\Http\ServerRequest))
#27 /var/www/html/api/vendor/middlewares/access-log/src/AccessLog.php(115): Slim\Routing\RouteRunner->handle(Object(Slim\Http\ServerRequest))
#28 /var/www/html/api/vendor/slim/slim/Slim/MiddlewareDispatcher.php(140): Middlewares\AccessLog->process(Object(Slim\Http\ServerRequest), Object(Slim\Routing\RouteRunner))
#29 /var/www/html/api/vendor/slim/slim/Slim/Middleware/ErrorMiddleware.php(107): class@anonymous->handle(Object(Slim\Http\ServerRequest))
#30 /var/www/html/api/vendor/slim/slim/Slim/MiddlewareDispatcher.php(140): Slim\Middleware\ErrorMiddleware->process(Object(Slim\Http\ServerRequest), Object(class@anonymous))
#31 /var/www/html/api/vendor/slim/slim/Slim/MiddlewareDispatcher.php(81): class@anonymous->handle(Object(Slim\Http\ServerRequest))
#32 /var/www/html/api/vendor/slim/slim/Slim/App.php(215): Slim\MiddlewareDispatcher->handle(Object(Slim\Http\ServerRequest))
#33 /var/www/html/api/vendor/slim/slim/Slim/App.php(199): Slim\App->handle(Object(Slim\Http\ServerRequest))
#34 /var/www/html/api/src/index.php(20): Slim\App->run()
#35 {main}
172.19.0.1 - - [20/Sep/2020:14:10:22 +0000] "GET /healthz HTTP/1.1" 500 21 "-" "curl/7.72.0" "192.168.1.21"
```

Access logs have been removed from php-fpm in favor of new logs in nginx-like format including X-Forwarded-For header:

```
172.19.0.1 - - [20/Sep/2020:14:10:36 +0000] "GET /healthz HTTP/1.1" 200 2 "-" "curl/7.72.0" "192.168.1.21"
```