### PR TITLE
Support response body size in NonBufferedBody

### DIFF
--- a/api/src/Http/NonBufferedBody.php
+++ b/api/src/Http/NonBufferedBody.php
@@ -1,0 +1,29 @@
+<?php
+declare(strict_types=1);
+
+namespace HomoChecker\Http;
+
+use Slim\Psr7\NonBufferedBody as NonBufferedBodyBase;
+
+class NonBufferedBody extends NonBufferedBodyBase
+{
+    protected $size = 0;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getSize(): ?int
+    {
+        return $this->size;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function write($string): int
+    {
+        $size = parent::write($string);
+        $this->size += $size;
+        return $size;
+    }
+}

--- a/api/src/Providers/HomoProvider.php
+++ b/api/src/Providers/HomoProvider.php
@@ -8,6 +8,7 @@ use GuzzleHttp\ClientInterface;
 use HomoChecker\Contracts\Service\CacheService as CacheServiceContract;
 use HomoChecker\Contracts\Service\CheckService as CheckServiceContract;
 use HomoChecker\Contracts\Service\HomoService as HomoServiceContract;
+use HomoChecker\Http\NonBufferedBody;
 use HomoChecker\Service\CacheService;
 use HomoChecker\Service\CheckService;
 use HomoChecker\Service\HomoService;
@@ -22,7 +23,6 @@ use Illuminate\Support\ServiceProvider;
 use Middlewares\AccessLog;
 use Psr\Http\Message\StreamInterface;
 use Psr\Log\LoggerInterface;
-use Slim\Psr7\NonBufferedBody;
 
 class HomoProvider extends ServiceProvider
 {


### PR DESCRIPTION
Adds support for logging the size of non-buffered body.


```
172.19.0.1 - - [20/Sep/2020:14:48:25 +0000] "GET /check/ HTTP/1.1" 200 - "-" "curl/7.72.0" "-"
```

↓

```
172.19.0.1 - - [20/Sep/2020:14:47:43 +0000] "GET /check/ HTTP/1.1" 200 10468 "-" "curl/7.72.0" "-"
```