### PR TITLE
Disable cache for Check API

### DIFF
--- a/api/src/Action/CheckAction.php
+++ b/api/src/Action/CheckAction.php
@@ -30,12 +30,17 @@ class CheckAction
     {
         /** @var Response $response */
         $result = $this->check->execute($screen_name);
-        return $response->withJson($result, !empty($result) ? 200 : 404);
+        return $response
+            ->withHeader('Cache-Control', 'no-store')
+            ->withJson($result, !empty($result) ? 200 : 404);
     }
 
     protected function bySSE(Response $response, string $screen_name = null): Response
     {
-        $response = $response->withBody($this->stream)->withHeader('Content-Type', 'text/event-stream');
+        $response = $response
+            ->withBody($this->stream)
+            ->withHeader('Content-Type', 'text/event-stream')
+            ->withHeader('Cache-Control', 'no-store');
 
         // Output count
         $count = [

--- a/api/tests/Case/Action/CheckActionTest.php
+++ b/api/tests/Case/Action/CheckActionTest.php
@@ -113,8 +113,12 @@ class CheckActionTest extends TestCase
 
         $action = new CheckAction($check, $homo, $stream);
         $response = $action(new HttpRequest($request), new HttpResponse(new Response(), new StreamFactory()), []);
+
         $actual = $response->getHeaderLine('Content-Type');
         $this->assertMatchesRegularExpression('|^application/json|', $actual);
+
+        $actual = $response->getHeaderLine('Cache-Control');
+        $this->assertEquals('no-store', $actual);
 
         $actual = (string) $response->getBody();
         $expected = json_encode([
@@ -167,7 +171,7 @@ class CheckActionTest extends TestCase
                 'error' => null,
             ],
         ]);
-        $this->assertJsonStringEqualsJsonString($actual, $expected);
+        $this->assertJsonStringEqualsJsonString($expected, $actual);
     }
 
     /**
@@ -228,7 +232,13 @@ class CheckActionTest extends TestCase
               });
 
         $action = new CheckAction($check, $homo, $stream);
-        $action(new HttpRequest($request), new HttpResponse(new Response(), new StreamFactory()), []);
+        $response = $action(new HttpRequest($request), new HttpResponse(new Response(), new StreamFactory()), []);
+
+        $actual = $response->getHeaderLine('Content-Type');
+        $this->assertEquals('text/event-stream', $actual);
+
+        $actual = $response->getHeaderLine('Cache-Control');
+        $this->assertEquals('no-store', $actual);
     }
 
     public function formatProvider()


### PR DESCRIPTION
Some Web browsers like IE 11 store Server Sent Events by default so this PR tries to disable them.