### PR TITLE
Skip access log for /metrics in nginx

### DIFF
--- a/client/conf/default.conf.template
+++ b/client/conf/default.conf.template
@@ -11,7 +11,7 @@ server {
     keepalive_timeout 0;
 
     location @api {
-        if ($request_uri = /healthz) {
+        if ($request_uri ~ ^/(healthz|metrics)) {
             access_log off;
         }
 


### PR DESCRIPTION
Related: #1416 