### PR TITLE
Use preferred constants

### DIFF
--- a/api/src/Contracts/Service/Client/Response.php
+++ b/api/src/Contracts/Service/Client/Response.php
@@ -85,7 +85,7 @@ class Response implements ResponseInterface
         $this->httpVersion = match ($httpVersion) {
             CURL_HTTP_VERSION_1_0 => '1.0',
             CURL_HTTP_VERSION_1_1 => '1.1',
-            CURL_HTTP_VERSION_2_0 => '2',
+            CURL_HTTP_VERSION_2 => '2',
             default => null,
         };
     }

--- a/api/src/config.php
+++ b/api/src/config.php
@@ -54,7 +54,7 @@ return [
         'timeout' => 5,
         'allow_redirects' => false,
         'curl' => [
-            CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_2_0,
+            CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_2,
         ],
         'headers' => [
             'User-Agent' => 'Homozilla/5.0 (Checker/1.14.514; homOSeX 8.10)',
@@ -76,8 +76,5 @@ return [
         'token' => env('HOMOCHECKER_TWITTER_TOKEN'),
         'token_secret' => env('HOMOCHECKER_TWITTER_TOKEN_SECRET'),
     ],
-    'httpVersion' => '1.1',
-    'responseChunkSize' => 4096,
-    'routerCacheFile' => false,
     'regex' => '/https?:\/\/twitter\.com\/mpyw\/?/',
 ];

--- a/api/tests/Case/Service/CheckServiceTest.php
+++ b/api/tests/Case/Service/CheckServiceTest.php
@@ -113,7 +113,7 @@ class CheckServiceTest extends TestCase
                        $response = new Response(new Psr7Response(301, ['Location' => 'https://homo.example.com'], ''));
                        $response->setTotalTime(1.0);
                        $response->setStartTransferTime(2.0);
-                       $response->setHttpVersion(CURL_HTTP_VERSION_2_0);
+                       $response->setHttpVersion(CURL_HTTP_VERSION_2);
                        $response->setPrimaryIP('2001:db8::4545:1');
                        yield 'https://foo.example.com/1' => new FulfilledPromise($response);
                    })(),


### PR DESCRIPTION
> The alias _CURL_HTTP_VERSION_2_ was added in 7.43.0 to better reflect the actual protocol name. 

https://curl.se/libcurl/c/CURLOPT_HTTP_VERSION.html