### PR TITLE
Manually cache Alt-Svc rather than CURLOPT_ALTSVC

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,6 @@ $ export HOMOCHECKER_API_HOST=api
 #### PHP-FPM
 
 ```sh
-$ export HOMOCHECKER_ALTSVC_CACHE=/tmp/altsvc-cache.txt
 $ export HOMOCHECKER_DB_HOST=database
 $ export HOMOCHECKER_DB_PORT=5432
 $ export HOMOCHECKER_DB_USERNAME=homo

--- a/api/src/Contracts/Service/CacheService.php
+++ b/api/src/Contracts/Service/CacheService.php
@@ -6,8 +6,10 @@ namespace HomoChecker\Contracts\Service;
 /**
  * @method ?string loadIconMastodon(string $screen_name)
  * @method ?string loadIconTwitter(string $screen_name)
+ * @method ?string loadAltsvc(string $url)
  * @method void    saveIconMastodon(string $screen_name, string $url, ...$arguments)
  * @method void    saveIconTwitter(string $screen_name, string $url, ...$arguments)
+ * @method void    saveAltsvc(string $url, string $value, ...$arguments)
  */
 interface CacheService
 {

--- a/api/src/Contracts/Service/Client/Altsvc.php
+++ b/api/src/Contracts/Service/Client/Altsvc.php
@@ -1,0 +1,94 @@
+<?php
+declare(strict_types=1);
+
+namespace HomoChecker\Contracts\Service\Client;
+
+use Illuminate\Support\Collection;
+use Illuminate\Support\Str;
+
+class Altsvc
+{
+    /**
+     * @var bool Invalidates all alternatives.
+     */
+    protected bool $clear = false;
+
+    /**
+     * @var ?string The identifier for the protocol (e.g., h3).
+     */
+    protected ?string $protocolId;
+
+    /**
+     * @var ?string The alternative authority (e.g., :443).
+     */
+    protected ?string $altAuthority;
+
+    /**
+     * @var float The max age.
+     */
+    protected float $maxAge = 86400;
+
+    public function __construct(string $value)
+    {
+        /** @var Collection<string> $params */
+        $params = Str::of($value)
+            ->trim()
+            ->split('/\s*;\s*/')
+            ->map(fn (string $param) => Str::of($param)->split('/=/'))
+            ->map(fn (Collection $param) => $param->map(fn (string $v) => (string) Str::of($v)->trim('"'))->pad(2, '')->toArray())
+            ->toArray();
+
+        foreach ($params as [$key, $value]) {
+            switch ($key) {
+                case 'clear':
+                    $this->clear = true;
+                    break;
+                case 'ma':
+                    $this->maxAge = (float) $value;
+                    break;
+                case 'persist':
+                    break;
+                default:
+                    $this->protocolId = $key;
+                    $this->altAuthority = $value;
+                    break;
+            }
+        }
+    }
+
+    /**
+     * Get the value indicating whether to invalidate all alternatives.
+     * @return bool Whether to invalidate all alternatives.
+     */
+    public function isClear(): bool
+    {
+        return $this->clear;
+    }
+
+    /**
+     * Get the identifier for the protocol.
+     * @return ?string The identifier for the protocol.
+     */
+    public function getProtocolId(): ?string
+    {
+        return $this->protocolId;
+    }
+
+    /**
+     * Get the alternative authority.
+     * @return ?string The alternative authority.
+     */
+    public function getAltAuthority(): ?string
+    {
+        return $this->altAuthority;
+    }
+
+    /**
+     * Get the max age.
+     * @return float The max age.
+     */
+    public function getMaxAge(): float
+    {
+        return $this->maxAge;
+    }
+}

--- a/api/src/Providers/HomoHandlerProvider.php
+++ b/api/src/Providers/HomoHandlerProvider.php
@@ -24,7 +24,7 @@ class HomoHandlerProvider extends ServiceProvider
 
         $this->app->singleton(StreamFactoryInterface::class, StreamFactory::class);
         $this->app->singleton(ResponseFactoryInterface::class, function (Container $app) {
-            /** @var App */
+            /** @var App $slim */
             $slim = $app->make('app');
             return $slim->getResponseFactory();
         });

--- a/api/src/Providers/HomoMetricsProvider.php
+++ b/api/src/Providers/HomoMetricsProvider.php
@@ -22,7 +22,7 @@ class HomoMetricsProvider extends ServiceProvider
             ->give(fn (Container $app) => $app->make(APC::class));
 
         $this->app->singleton('collector.check_total', function (Container $app) {
-            /** @var RegistryInterface */
+            /** @var RegistryInterface $registry */
             $registry = $app->make(RegistryInterface::class);
             return $registry->registerCounter(
                 'homochecker',
@@ -33,7 +33,7 @@ class HomoMetricsProvider extends ServiceProvider
         });
 
         $this->app->singleton('collector.check_error_total', function (Container $app) {
-            /** @var RegistryInterface */
+            /** @var RegistryInterface $registry */
             $registry = $app->make(RegistryInterface::class);
             return $registry->registerCounter(
                 'homochecker',
@@ -44,7 +44,7 @@ class HomoMetricsProvider extends ServiceProvider
         });
 
         $this->app->singleton('collector.profile_error_total', function (Container $app) {
-            /** @var RegistryInterface */
+            /** @var RegistryInterface $registry */
             $registry = $app->make(RegistryInterface::class);
             return $registry->registerCounter(
                 'homochecker',
@@ -55,7 +55,7 @@ class HomoMetricsProvider extends ServiceProvider
         });
 
         $this->app->singleton('summary.http_server_requests_seconds', function (Container $app) {
-            /** @var RegistryInterface */
+            /** @var RegistryInterface $registry */
             $registry = $app->make(RegistryInterface::class);
             return $registry->registerSummary(
                 '',

--- a/api/src/Providers/HomoProvider.php
+++ b/api/src/Providers/HomoProvider.php
@@ -48,13 +48,13 @@ class HomoProvider extends ServiceProvider
             ->giveConfig('logging.skipPaths');
 
         $this->app->resolving(ErrorMiddleware::class, function (ErrorMiddleware $middleware, Container $app) {
-            /** @var ErrorHandlerInterface */
+            /** @var ErrorHandlerInterface $handler */
             $handler = $app->make(ErrorHandlerInterface::class);
             $middleware->setDefaultErrorHandler($handler);
         });
 
         $this->app->singleton(CallableResolverInterface::class, function (Container $app) {
-            /** @var App */
+            /** @var App $slim */
             $slim = $app->make('app');
             return $slim->getCallableResolver();
         });
@@ -66,7 +66,7 @@ class HomoProvider extends ServiceProvider
             ->needs('$skipPaths')
             ->giveConfig('logging.skipPaths');
         $this->app->singleton(RouteResolverInterface::class, function (Container $app) {
-            /** @var App */
+            /** @var App $slim */
             $slim = $app->make('app');
             return $slim->getRouteResolver();
         });
@@ -96,7 +96,7 @@ class HomoProvider extends ServiceProvider
 
         $this->app->resolving('db', function (DatabaseManager $databaseManager, Container $app) {
             $databaseManager->extend('pgsql', function (array $config, string $name) use ($app) {
-                /** @var ConnectionFactory */
+                /** @var ConnectionFactory $factory */
                 $factory = $app->make('db.factory');
 
                 // Ensure that the permission for the private key is set to 0600.

--- a/api/src/Service/CacheService.php
+++ b/api/src/Service/CacheService.php
@@ -10,8 +10,10 @@ use Illuminate\Support\Str;
 /**
  * @method ?string loadIconMastodon(string $screen_name)
  * @method ?string loadIconTwitter(string $screen_name)
+ * @method ?string loadAltsvc(string $url)
  * @method void    saveIconMastodon(string $screen_name, string $url, int $expire)
  * @method void    saveIconTwitter(string $screen_name, string $url, int $expire)
+ * @method void    saveAltsvc(string $url, string $value, int $expire)
  */
 class CacheService implements CacheServiceContract
 {

--- a/api/src/config.php
+++ b/api/src/config.php
@@ -55,7 +55,6 @@ return [
         'allow_redirects' => false,
         'curl' => [
             CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_2,
-            CURLOPT_ALTSVC => env('HOMOCHECKER_ALTSVC_CACHE', null),
         ],
         'headers' => [
             'User-Agent' => 'Homozilla/5.0 (Checker/1.14.514; homOSeX 8.10)',

--- a/api/tests/Case/Action/BadgeActionTest.php
+++ b/api/tests/Case/Action/BadgeActionTest.php
@@ -84,10 +84,10 @@ class BadgeActionTest extends TestCase
 
     public function testAllCount(): void
     {
-        /** @var CheckService|MockInterface $check */
+        /** @var CheckService&MockInterface $check */
         $check = m::mock(CheckService::class);
 
-        /** @var HomoService|MockInterface $homo */
+        /** @var HomoService&MockInterface $homo */
         $homo = m::mock(HomoService::class);
         $homo->shouldReceive('count')
              ->andReturn(3);
@@ -103,12 +103,12 @@ class BadgeActionTest extends TestCase
 
     public function testStatusCount(): void
     {
-        /** @var CheckService|MockInterface $check */
+        /** @var CheckService&MockInterface $check */
         $check = m::mock(CheckService::class);
         $check->shouldReceive('execute')
               ->andReturn($this->statuses);
 
-        /** @var HomoService|MockInterface $homo */
+        /** @var HomoService&MockInterface $homo */
         $homo = m::mock(HomoService::class);
 
         $action = new BadgeAction($check, $homo);
@@ -122,10 +122,10 @@ class BadgeActionTest extends TestCase
 
     public function testParams(): void
     {
-        /** @var CheckService|MockInterface $check */
+        /** @var CheckService&MockInterface $check */
         $check = m::mock(CheckService::class);
 
-        /** @var HomoService|MockInterface $homo */
+        /** @var HomoService&MockInterface $homo */
         $homo = m::mock(HomoService::class);
         $homo->shouldReceive('count')
              ->andReturn(3);

--- a/api/tests/Case/Action/CheckActionTest.php
+++ b/api/tests/Case/Action/CheckActionTest.php
@@ -102,13 +102,13 @@ class CheckActionTest extends TestCase
     {
         $request = (new RequestFactory())->createRequest('GET', '/check?format=json');
 
-        /** @var CheckService|MockInterface $check */
+        /** @var CheckService&MockInterface $check */
         $check = m::mock(CheckService::class);
         $check->shouldReceive('execute')
               ->with(null)
               ->andReturn($this->statuses);
 
-        /** @var HomoService|MockInterface $homo */
+        /** @var HomoService&MockInterface $homo */
         $homo = m::mock(HomoService::class);
 
         /** @var StreamInterface $stream */
@@ -187,13 +187,13 @@ class CheckActionTest extends TestCase
     {
         $request = (new RequestFactory())->createRequest('GET', "/check?format={$format}");
 
-        /** @var HomoService|MockInterface $homo */
+        /** @var HomoService&MockInterface $homo */
         $homo = m::mock(HomoService::class);
         $homo->shouldReceive('count')
              ->with(null)
              ->andReturn(3);
 
-        /** @var MockInterface|StreamInterface $stream */
+        /** @var MockInterface&StreamInterface $stream */
         $stream = m::mock(StreamInterface::class);
         $stream->shouldReceive('write')
                ->once()
@@ -227,7 +227,7 @@ class CheckActionTest extends TestCase
                ->once()
                ->with("data: {\"homo\":{\"screen_name\":\"bar\",\"service\":\"mastodon\",\"url\":\"http:\\/\\/bar.example.com\",\"display_url\":\"bar.example.com\",\"secure\":false,\"icon\":\"https:\\/\\/icon.example.com\\/3\"},\"status\":\"OK\",\"code\":\"200 OK\",\"http\":\"1.1\",\"ip\":\"2001:db8::4545:3\",\"url\":\"https:\\/\\/bar.example.com\\/2\",\"duration\":30,\"error\":null}\n\n");
 
-        /** @var CheckService|MockInterface $check */
+        /** @var CheckService&MockInterface $check */
         $check = m::mock(CheckService::class);
         $check->shouldReceive('execute')
               ->withArgs(function (?string $screen_name, callable $callback) {

--- a/api/tests/Case/Action/HealthCheckActionTest.php
+++ b/api/tests/Case/Action/HealthCheckActionTest.php
@@ -29,7 +29,7 @@ class HealthCheckActionTest extends TestCase
 
     public function testOK(): void
     {
-        /** @var HomoService|MockInterface $homo */
+        /** @var HomoService&MockInterface $homo */
         $homo = m::mock(HomoService::class);
         $homo->shouldReceive('count')
              ->andReturn(3);
@@ -50,7 +50,7 @@ class HealthCheckActionTest extends TestCase
 
     public function testInternalServerError(): void
     {
-        /** @var HomoService|MockInterface $homo */
+        /** @var HomoService&MockInterface $homo */
         $homo = m::mock(HomoService::class);
         $homo->shouldReceive('count')
              ->andThrow($e = new Exception('Internal Server Error'));

--- a/api/tests/Case/Action/ListActionTest.php
+++ b/api/tests/Case/Action/ListActionTest.php
@@ -42,7 +42,7 @@ class ListActionTest extends TestCase
 
     public function testListByJSON(): void
     {
-        /** @var HomoService|MockInterface $homo */
+        /** @var HomoService&MockInterface $homo */
         $homo = m::mock(HomoService::class);
         $homo->shouldReceive('find')
              ->with(null)
@@ -90,7 +90,7 @@ class ListActionTest extends TestCase
 
     public function testListWithNotFoundByJSON(): void
     {
-        /** @var HomoService|MockInterface $homo */
+        /** @var HomoService&MockInterface $homo */
         $homo = m::mock(HomoService::class);
         $homo->shouldReceive('find')
              ->with('baz')
@@ -122,7 +122,7 @@ class ListActionTest extends TestCase
         insert into "users" ("screen_name", "service", "url") values ('bar', 'twitter', 'https://bar.example.com');
         SQL;
 
-        /** @var HomoService|MockInterface $homo */
+        /** @var HomoService&MockInterface $homo */
         $homo = m::mock(HomoService::class);
         $homo->shouldReceive('export')
              ->andReturn($sql);

--- a/api/tests/Case/Action/MetricsActionTest.php
+++ b/api/tests/Case/Action/MetricsActionTest.php
@@ -108,12 +108,12 @@ class MetricsActionTest extends TestCase
         homochecker_check_total{status="ERROR",code="0",screen_name="baz",url="https://baz.example.com"} 2
         METRICS;
 
-        /** @var MockInterface|RegistryInterface $registry */
+        /** @var MockInterface&RegistryInterface $registry */
         $registry = m::mock(RegistryInterface::class);
         $registry->shouldReceive('getMetricFamilySamples')
                  ->andReturn($metrics);
 
-        /** @var MockInterface|RendererInterface $renderer */
+        /** @var MockInterface&RendererInterface $renderer */
         $renderer = m::mock(RendererInterface::class);
         $renderer->shouldReceive('render')
                  ->withArgs([$metrics])

--- a/api/tests/Case/Http/ErrorResponseTest.php
+++ b/api/tests/Case/Http/ErrorResponseTest.php
@@ -20,7 +20,7 @@ class ErrorResponseTest extends TestCase
     {
         $response = new HttpResponse(new Response(500), new StreamFactory());
 
-        /** @var MockInterface|StreamFactoryInterface $streamFactory */
+        /** @var MockInterface&StreamFactoryInterface $streamFactory */
         $streamFactory = m::mock(StreamFactoryInterface::class);
 
         $errorResponse = new ErrorResponse($response, $streamFactory);
@@ -34,7 +34,7 @@ class ErrorResponseTest extends TestCase
         $response = new HttpResponse(new Response(500), new StreamFactory());
         $exception = new PDOException('SQLSTATE[08006] [7] could not translate host name "database" to address: Name or service not known');
 
-        /** @var MockInterface|StreamFactoryInterface $streamFactory */
+        /** @var MockInterface&StreamFactoryInterface $streamFactory */
         $streamFactory = m::mock(StreamFactoryInterface::class);
 
         $errorResponse = new ErrorResponse($response, $streamFactory);
@@ -49,7 +49,7 @@ class ErrorResponseTest extends TestCase
         $response = new HttpResponse(new Response(500), new StreamFactory());
         $exception = new PDOException('SQLSTATE[08006] [7] could not translate host name "database" to address: Name or service not known');
 
-        /** @var MockInterface|StreamFactoryInterface $streamFactory */
+        /** @var MockInterface&StreamFactoryInterface $streamFactory */
         $streamFactory = m::mock(StreamFactoryInterface::class);
 
         $errorResponse = new ErrorResponse($response, $streamFactory);
@@ -65,10 +65,10 @@ class ErrorResponseTest extends TestCase
         $response = new HttpResponse(new Response(500), new StreamFactory());
         $exception = new PDOException('SQLSTATE[08006] [7] could not translate host name "database" to address: Name or service not known');
 
-        /** @var MockInterface|StreamFactoryInterface $streamFactory */
+        /** @var MockInterface&StreamFactoryInterface $streamFactory */
         $streamFactory = m::mock(StreamFactoryInterface::class);
 
-        /** @var MockInterface|StreamInterface */
+        /** @var MockInterface&StreamInterface $body */
         $body = m::mock(StreamInterface::class);
 
         $errorResponse = new ErrorResponse($response, $streamFactory);
@@ -84,7 +84,7 @@ class ErrorResponseTest extends TestCase
         $response = new HttpResponse(new Response(500), new StreamFactory());
         $exception = new PDOException('SQLSTATE[08006] [7] could not translate host name "database" to address: Name or service not known');
 
-        /** @var MockInterface|StreamFactoryInterface $streamFactory */
+        /** @var MockInterface&StreamFactoryInterface $streamFactory */
         $streamFactory = m::mock(StreamFactoryInterface::class);
 
         $errorResponse = new ErrorResponse($response, $streamFactory);
@@ -100,7 +100,7 @@ class ErrorResponseTest extends TestCase
         $response = new HttpResponse(new Response(500), new StreamFactory());
         $exception = new PDOException('SQLSTATE[08006] [7] could not translate host name "database" to address: Name or service not known');
 
-        /** @var MockInterface|StreamFactoryInterface $streamFactory */
+        /** @var MockInterface&StreamFactoryInterface $streamFactory */
         $streamFactory = m::mock(StreamFactoryInterface::class);
 
         $errorResponse = new ErrorResponse($response, $streamFactory);
@@ -116,7 +116,7 @@ class ErrorResponseTest extends TestCase
         $response = new HttpResponse(new Response(500), new StreamFactory());
         $exception = new PDOException('SQLSTATE[08006] [7] could not translate host name "database" to address: Name or service not known');
 
-        /** @var MockInterface|StreamFactoryInterface $streamFactory */
+        /** @var MockInterface&StreamFactoryInterface $streamFactory */
         $streamFactory = m::mock(StreamFactoryInterface::class);
 
         $errorResponse = new ErrorResponse($response, $streamFactory);
@@ -132,7 +132,7 @@ class ErrorResponseTest extends TestCase
         $response = new HttpResponse(new Response(500), new StreamFactory());
         $exception = new PDOException('SQLSTATE[08006] [7] could not translate host name "database" to address: Name or service not known');
 
-        /** @var MockInterface|StreamFactoryInterface $streamFactory */
+        /** @var MockInterface&StreamFactoryInterface $streamFactory */
         $streamFactory = m::mock(StreamFactoryInterface::class);
 
         $errorResponse = new ErrorResponse($response, $streamFactory);
@@ -148,10 +148,10 @@ class ErrorResponseTest extends TestCase
         $response = new HttpResponse(new Response(500), new StreamFactory());
         $exception = new PDOException('SQLSTATE[08006] [7] could not translate host name "database" to address: Name or service not known');
 
-        /** @var MockInterface|StreamInterface */
+        /** @var MockInterface&StreamInterface $body */
         $body = m::mock(StreamInterface::class);
 
-        /** @var MockInterface|StreamFactoryInterface $streamFactory */
+        /** @var MockInterface&StreamFactoryInterface $streamFactory */
         $streamFactory = m::mock(StreamFactoryInterface::class);
         $streamFactory->shouldReceive('createStream')
                       ->withArgs(['{"errors":[{"code":500,"message":"Internal server error"}]}'])
@@ -177,7 +177,7 @@ class ErrorResponseTest extends TestCase
         $response = new HttpResponse(new Response(500), new StreamFactory());
         $exception = new PDOException('SQLSTATE[08006] [7] could not translate host name "database" to address: Name or service not known');
 
-        /** @var MockInterface|StreamFactoryInterface $streamFactory */
+        /** @var MockInterface&StreamFactoryInterface $streamFactory */
         $streamFactory = m::mock(StreamFactoryInterface::class);
 
         $errorResponse = new ErrorResponse($response, $streamFactory);
@@ -193,12 +193,12 @@ class ErrorResponseTest extends TestCase
         $response = new HttpResponse(new Response(500), new StreamFactory());
         $exception = new PDOException('SQLSTATE[08006] [7] could not translate host name "database" to address: Name or service not known');
 
-        /** @var MockInterface|StreamInterface */
+        /** @var MockInterface&StreamInterface $body */
         $body = m::mock(StreamInterface::class);
         $body->shouldReceive('getMetadata')
              ->andReturn([]);
 
-        /** @var MockInterface|StreamFactoryInterface $streamFactory */
+        /** @var MockInterface&StreamFactoryInterface $streamFactory */
         $streamFactory = m::mock(StreamFactoryInterface::class);
 
         $errorResponse = new ErrorResponse($response, $streamFactory);
@@ -214,12 +214,12 @@ class ErrorResponseTest extends TestCase
         $response = new HttpResponse(new Response(500), new StreamFactory());
         $exception = new PDOException('SQLSTATE[08006] [7] could not translate host name "database" to address: Name or service not known');
 
-        /** @var MockInterface|StreamInterface */
+        /** @var MockInterface&StreamInterface $body */
         $body = m::mock(StreamInterface::class);
         $body->shouldReceive('getMetadata')
              ->andReturn([]);
 
-        /** @var MockInterface|StreamFactoryInterface $streamFactory */
+        /** @var MockInterface&StreamFactoryInterface $streamFactory */
         $streamFactory = m::mock(StreamFactoryInterface::class);
 
         $errorResponse = new ErrorResponse($response, $streamFactory);

--- a/api/tests/Case/Http/Factory/ErrorResponseFactoryTest.php
+++ b/api/tests/Case/Http/Factory/ErrorResponseFactoryTest.php
@@ -20,10 +20,10 @@ class ErrorResponseFactoryTest extends TestCase
     {
         $response = new HttpResponse(new Response(500), new StreamFactory());
 
-        /** @var MockInterface|StreamFactoryInterface $streamFactory */
+        /** @var MockInterface&StreamFactoryInterface $streamFactory */
         $streamFactory = m::mock(StreamFactoryInterface::class);
 
-        /** @var MockInterface|ResponseFactoryInterface $responseFactory */
+        /** @var MockInterface&ResponseFactoryInterface $responseFactory */
         $responseFactory = m::mock(ResponseFactoryInterface::class);
         $responseFactory->shouldReceive('createResponse')
                         ->withArgs([500, 'Internal server error'])

--- a/api/tests/Case/Http/NonBufferedBodyTest.php
+++ b/api/tests/Case/Http/NonBufferedBodyTest.php
@@ -19,7 +19,7 @@ class NonBufferedBodyTest extends TestCase
      */
     public function testWrite(): void
     {
-        /** @var MockInterface|Psr7NonBufferedBody $base */
+        /** @var MockInterface&Psr7NonBufferedBody $base */
         $base = m::mock('overload:' . Psr7NonBufferedBody::class);
         $base->size = 0;
         $base->shouldReceive('write')

--- a/api/tests/Case/Logging/CustomizeFormatterTest.php
+++ b/api/tests/Case/Logging/CustomizeFormatterTest.php
@@ -20,18 +20,18 @@ class CustomizeFormatterTest extends TestCase
     public function testInvoke(): void
     {
         /** @var LineFormatter $formatter1 */
-        /** @var HandlerWrapper|MockInterface */
+        /** @var HandlerWrapper&MockInterface $handler1 */
         $handler1 = m::mock(HandlerWrapper::class);
         $handler1->shouldReceive('setFormatter')
                  ->with(m::capture($formatter1));
 
         /** @var LineFormatter $formatter2 */
-        /** @var HandlerWrapper|MockInterface */
+        /** @var HandlerWrapper&MockInterface $handler2 */
         $handler2 = m::mock(HandlerWrapper::class);
         $handler2->shouldReceive('setFormatter')
                  ->with(m::capture($formatter2));
 
-        /** @var LoggerInterface|MockInterface */
+        /** @var LoggerInterface&MockInterface $logger */
         $logger = m::mock(LoggerInterface::class);
         $logger->shouldReceive('getHandlers')
                ->andReturn([$handler1, $handler2]);

--- a/api/tests/Case/Middleware/AccessLogMiddlewareTest.php
+++ b/api/tests/Case/Middleware/AccessLogMiddlewareTest.php
@@ -28,10 +28,10 @@ class AccessLogMiddlewareTest extends TestCase
         $request = (new ServerRequestFactory())->createServerRequest('GET', '/metrics');
         $response = new HttpResponse(new Response(), new StreamFactory());
 
-        /** @var LoggerInterface|MockInterface $logger */
+        /** @var LoggerInterface&MockInterface $logger */
         $logger = m::mock(LoggerInterface::class);
 
-        /** @var MockInterface|RequestHandlerInterface $handler */
+        /** @var MockInterface&RequestHandlerInterface $handler */
         $handler = m::mock(RequestHandlerInterface::class);
         $handler->shouldReceive('handle')
                 ->withArgs([$request])
@@ -51,13 +51,13 @@ class AccessLogMiddlewareTest extends TestCase
         $request = (new ServerRequestFactory())->createServerRequest('GET', '/check');
         $response = new HttpResponse(new Response(), new StreamFactory());
 
-        /** @var LoggerInterface|MockInterface $logger */
+        /** @var LoggerInterface&MockInterface $logger */
         $logger = m::mock(LoggerInterface::class);
 
-        /** @var MockInterface|RequestHandlerInterface $handler */
+        /** @var MockInterface&RequestHandlerInterface $handler */
         $handler = m::mock(RequestHandlerInterface::class);
 
-        /** @var AccessLog|MockInterface $base */
+        /** @var AccessLog&MockInterface $base */
         $base = m::mock('overload:' . AccessLog::class);
         $base->shouldReceive('process')
              ->withArgs([$request, $handler])

--- a/api/tests/Case/Middleware/ErrorMiddlewareTest.php
+++ b/api/tests/Case/Middleware/ErrorMiddlewareTest.php
@@ -29,22 +29,22 @@ class ErrorMiddlewareTest extends TestCase
         $exception = new HttpNotFoundException($request);
         $response = new ErrorResponse(new Response(), new StreamFactory());
 
-        /** @var ErrorHandlerInterface|MockInterface $errorHandler */
+        /** @var ErrorHandlerInterface&MockInterface $errorHandler */
         $errorHandler = m::mock(ErrorHandlerInterface::class);
         $errorHandler->shouldReceive('__invoke')
                      ->withArgs([$request, $exception, false, false, false])
                      ->andReturn($response);
 
-        /** @var CallableResolverInterface|MockInterface $callableResolver */
+        /** @var CallableResolverInterface&MockInterface $callableResolver */
         $callableResolver = m::mock(CallableResolverInterface::class);
         $callableResolver->shouldReceive('resolve')
                          ->withArgs([$errorHandler])
                          ->andReturn($errorHandler);
 
-        /** @var MockInterface|ResponseFactoryInterface $responseFactory */
+        /** @var MockInterface&ResponseFactoryInterface $responseFactory */
         $responseFactory = m::mock(ResponseFactoryInterface::class);
 
-        /** @var MockInterface|RequestHandlerInterface $handler */
+        /** @var MockInterface&RequestHandlerInterface $handler */
         $handler = m::mock(RequestHandlerInterface::class);
         $handler->shouldReceive('handle')
                 ->withArgs([$request])
@@ -63,22 +63,22 @@ class ErrorMiddlewareTest extends TestCase
         $response = new ErrorResponse(new Response(), new StreamFactory());
         $exception = new RuntimeException();
 
-        /** @var ErrorHandlerInterface|MockInterface $errorHandler */
+        /** @var ErrorHandlerInterface&MockInterface $errorHandler */
         $errorHandler = m::mock(ErrorHandlerInterface::class);
         $errorHandler->shouldReceive('__invoke')
                      ->withArgs([$request, $exception, false, false, false])
                      ->andReturn($response);
 
-        /** @var CallableResolverInterface|MockInterface $callableResolver */
+        /** @var CallableResolverInterface&MockInterface $callableResolver */
         $callableResolver = m::mock(CallableResolverInterface::class);
         $callableResolver->shouldReceive('resolve')
                          ->withArgs([$errorHandler])
                          ->andReturn($errorHandler);
 
-        /** @var MockInterface|ResponseFactoryInterface $responseFactory */
+        /** @var MockInterface&ResponseFactoryInterface $responseFactory */
         $responseFactory = m::mock(ResponseFactoryInterface::class);
 
-        /** @var MockInterface|RequestHandlerInterface $handler */
+        /** @var MockInterface&RequestHandlerInterface $handler */
         $handler = m::mock(RequestHandlerInterface::class);
         $handler->shouldReceive('handle')
                 ->withArgs([$request])

--- a/api/tests/Case/Middleware/MetricsMiddlewareTest.php
+++ b/api/tests/Case/Middleware/MetricsMiddlewareTest.php
@@ -33,13 +33,13 @@ class MetricsMiddlewareTest extends TestCase
         $request = (new ServerRequestFactory())->createServerRequest('GET', '/metrics');
         $response = new HttpResponse(new Response(), new StreamFactory());
 
-        /** @var MockInterface|Summary $summary */
+        /** @var MockInterface&Summary $summary */
         $summary = m::mock(Summary::class);
 
         /** @var MockIntercae|RouteResolverInterface $routeResolver */
         $routeResolver = m::mock(RouteResolverInterface::class);
 
-        /** @var MockInterface|RequestHandlerInterface $handler */
+        /** @var MockInterface&RequestHandlerInterface $handler */
         $handler = m::mock(RequestHandlerInterface::class);
         $handler->shouldReceive('handle')
                 ->withArgs([$request])
@@ -56,7 +56,7 @@ class MetricsMiddlewareTest extends TestCase
         $request = (new ServerRequestFactory())->createServerRequest('GET', '/not_found');
         $response = new ErrorResponse(new Response(StatusCodeInterface::STATUS_NOT_FOUND), new StreamFactory());
 
-        /** @var MockInterface|Summary $summary */
+        /** @var MockInterface&Summary $summary */
         $summary = m::mock(Summary::class);
         $summary->shouldReceive('observe')
                 ->withArgs(function (float $value, array $labels): bool {
@@ -73,18 +73,18 @@ class MetricsMiddlewareTest extends TestCase
                 })
                 ->andReturn();
 
-        /** @var DispatcherInterface|MockInterface $dispatcher */
+        /** @var DispatcherInterface&MockInterface $dispatcher */
         $dispatcher = m::mock(DispatcherInterface::class);
 
         $results = new RoutingResults($dispatcher, 'GET', '/not_found', RoutingResults::NOT_FOUND);
 
-        /** @var MockInterface|RouteResolverInterface $routeResolver */
+        /** @var MockInterface&RouteResolverInterface $routeResolver */
         $routeResolver = m::mock(RouteResolverInterface::class);
         $routeResolver->shouldReceive('computeRoutingResults')
                       ->withArgs(['/not_found', 'GET'])
                       ->andReturn($results);
 
-        /** @var MockInterface|RequestHandlerInterface $handler */
+        /** @var MockInterface&RequestHandlerInterface $handler */
         $handler = m::mock(RequestHandlerInterface::class);
         $handler->shouldReceive('handle')
                 ->withArgs([$request])
@@ -102,7 +102,7 @@ class MetricsMiddlewareTest extends TestCase
         $exception = new PDOException('SQLSTATE[08006] [7] could not translate host name "database" to address: Name or service not known');
         $response = (new ErrorResponse(new Response(StatusCodeInterface::STATUS_INTERNAL_SERVER_ERROR), new StreamFactory()))->withException($exception);
 
-        /** @var MockInterface|Summary $summary */
+        /** @var MockInterface&Summary $summary */
         $summary = m::mock(Summary::class);
         $summary->shouldReceive('observe')
                 ->withArgs(function (float $value, array $labels): bool {
@@ -119,19 +119,19 @@ class MetricsMiddlewareTest extends TestCase
                 })
                 ->andReturn();
 
-        /** @var DispatcherInterface|MockInterface $dispatcher */
+        /** @var DispatcherInterface&MockInterface $dispatcher */
         $dispatcher = m::mock(DispatcherInterface::class);
 
-        /** @var CallableResolverInterface|MockInterface $callableResolver */
+        /** @var CallableResolverInterface&MockInterface $callableResolver */
         $callableResolver = m::mock(CallableResolverInterface::class);
 
-        /** @var MockInterface|ResponseFactoryInterface $responseFactory */
+        /** @var MockInterface&ResponseFactoryInterface $responseFactory */
         $responseFactory = m::mock(ResponseFactoryInterface::class);
 
         $results = new RoutingResults($dispatcher, 'GET', '/list', RoutingResults::FOUND, 'route0', []);
         $route = new Route(['GET'], '/list[/[{name}[/]]]', fn () => null, $responseFactory, $callableResolver);
 
-        /** @var MockInterface|RouteResolverInterface $routeResolver */
+        /** @var MockInterface&RouteResolverInterface $routeResolver */
         $routeResolver = m::mock(RouteResolverInterface::class);
         $routeResolver->shouldReceive('computeRoutingResults')
                       ->withArgs(['/list', 'GET'])
@@ -140,7 +140,7 @@ class MetricsMiddlewareTest extends TestCase
                       ->withArgs(['route0'])
                       ->andReturn($route);
 
-        /** @var MockInterface|RequestHandlerInterface $handler */
+        /** @var MockInterface&RequestHandlerInterface $handler */
         $handler = m::mock(RequestHandlerInterface::class);
         $handler->shouldReceive('handle')
                 ->withArgs([$request])

--- a/api/tests/Case/Service/CheckServiceTest.php
+++ b/api/tests/Case/Service/CheckServiceTest.php
@@ -74,12 +74,13 @@ class CheckServiceTest extends TestCase
 
     public function testExecuteAsync(): void
     {
-        /** @var HomoService|MockInterface $homo */
+        /** @var HomoService&MockInterface $homo */
         $homo = m::mock(HomoService::class);
         $homo->shouldReceive('find')
              ->with(null)
              ->andReturn($this->users);
 
+        /** @var ProfileService&MockInterface $twitter */
         $twitter = m::mock(ProfileService::class);
         $twitter->shouldReceive('getIconAsync')
                 ->andReturn(
@@ -87,6 +88,7 @@ class CheckServiceTest extends TestCase
                     new FulfilledPromise('https://img.example.com/foo'),
                 );
 
+        /** @var ProfileService&MockInterface $mastodon */
         $mastodon = m::mock(ProfileService::class);
         $mastodon->shouldReceive('getIconAsync')
                  ->andReturn(
@@ -95,6 +97,7 @@ class CheckServiceTest extends TestCase
                      new FulfilledPromise('https://img.example.com/qux'),
                  );
 
+        /** @var ValidatorService&MockInterface $validator */
         $validator = m::mock(ValidatorService::class);
         $validator->shouldReceive('validate')
                   ->andReturn(
@@ -104,7 +107,7 @@ class CheckServiceTest extends TestCase
                       false,
                   );
 
-        /** @var ClientService|MockInterface $client */
+        /** @var ClientService&MockInterface $client */
         $client = m::mock(ClientService::class);
         $client->shouldReceive('getAsync')
                ->withArgs(['https://foo.example.com/1'])
@@ -178,7 +181,7 @@ class CheckServiceTest extends TestCase
                    })(),
                );
 
-        /** @var Counter|MockInterface $checkCounter */
+        /** @var Counter&MockInterface $checkCounter */
         $checkCounter = m::mock(Counter::class);
         $checkCounter->shouldReceive('inc')
                      ->withArgs([
@@ -230,7 +233,7 @@ class CheckServiceTest extends TestCase
                          ],
                      ]);
 
-        /** @var Counter|MockInterface $checkErrorCounter */
+        /** @var Counter&MockInterface $checkErrorCounter */
         $checkErrorCounter = m::mock(Counter::class);
         $checkErrorCounter->shouldReceive('inc')
                           ->withArgs([

--- a/api/tests/Case/Service/Client/AltsvcTest.php
+++ b/api/tests/Case/Service/Client/AltsvcTest.php
@@ -1,0 +1,26 @@
+<?php
+declare(strict_types=1);
+
+namespace HomoChecker\Test\Service\Client;
+
+use HomoChecker\Contracts\Service\Client\Altsvc;
+use PHPUnit\Framework\TestCase;
+
+class AltsvcTest extends TestCase
+{
+    public function testConstructClear(): void
+    {
+        $actual = new Altsvc('clear');
+
+        $this->assertTrue($actual->isClear());
+    }
+
+    public function testConstructProtocol(): void
+    {
+        $actual = new Altsvc('h3=":443"; ma=86400; persist');
+
+        $this->assertEquals('h3', $actual->getProtocolId());
+        $this->assertEquals(':443', $actual->getAltAuthority());
+        $this->assertEquals(86400, $actual->getMaxAge());
+    }
+}

--- a/api/tests/Case/Service/Client/ResponseTest.php
+++ b/api/tests/Case/Service/Client/ResponseTest.php
@@ -17,7 +17,7 @@ class ResponseTest extends TestCase
 
     public function testConstruct(): void
     {
-        /** @var MockInterface|Response */
+        /** @var MockInterface&Response $response */
         $response = m::mock(Psr7Response::class);
 
         $actual = new Response($response);
@@ -32,7 +32,7 @@ class ResponseTest extends TestCase
 
     public function testGetStatus(): void
     {
-        /** @var MockInterface|Response */
+        /** @var MockInterface&Response $response */
         $response = m::mock(Psr7Response::class);
         $response->shouldReceive('getStatusCode')
                  ->andReturn(404);
@@ -44,7 +44,7 @@ class ResponseTest extends TestCase
 
     public function testGetReasonPhrase(): void
     {
-        /** @var MockInterface|Response */
+        /** @var MockInterface&Response $response */
         $response = m::mock(Psr7Response::class);
         $response->shouldReceive('getReasonPhrase')
                  ->andReturn('Not Found');
@@ -56,7 +56,7 @@ class ResponseTest extends TestCase
 
     public function testWithStatus(): void
     {
-        /** @var MockInterface|Response */
+        /** @var MockInterface&Response $response */
         $response = m::mock(Psr7Response::class);
         $response->shouldReceive('withStatus')
                  ->withArgs([302, 'Found'])
@@ -71,7 +71,7 @@ class ResponseTest extends TestCase
 
     public function testGetProtocolVersion(): void
     {
-        /** @var MockInterface|Response */
+        /** @var MockInterface&Response $response */
         $response = m::mock(Psr7Response::class);
         $response->shouldReceive('getProtocolVersion')
                  ->andReturn('1.1');
@@ -83,7 +83,7 @@ class ResponseTest extends TestCase
 
     public function testWithProtocolVersion(): void
     {
-        /** @var MockInterface|Response */
+        /** @var MockInterface&Response $response */
         $response = m::mock(Psr7Response::class);
         $response->shouldReceive('withProtocolVersion')
                  ->withArgs(['1.0'])
@@ -98,7 +98,7 @@ class ResponseTest extends TestCase
 
     public function testGetHeaders(): void
     {
-        /** @var MockInterface|Response */
+        /** @var MockInterface&Response $response */
         $response = m::mock(Psr7Response::class);
         $response->shouldReceive('getHeaders')
                  ->andReturn(['Location' => 'https://example.com']);
@@ -110,7 +110,7 @@ class ResponseTest extends TestCase
 
     public function testHasHeader(): void
     {
-        /** @var MockInterface|Response */
+        /** @var MockInterface&Response $response */
         $response = m::mock(Psr7Response::class);
         $response->shouldReceive('hasHeader')
                  ->withArgs(['Location'])
@@ -123,7 +123,7 @@ class ResponseTest extends TestCase
 
     public function testGetHeader(): void
     {
-        /** @var MockInterface|Response */
+        /** @var MockInterface&Response $response */
         $response = m::mock(Psr7Response::class);
         $response->shouldReceive('getHeader')
                  ->withArgs(['Location'])
@@ -136,7 +136,7 @@ class ResponseTest extends TestCase
 
     public function testWithHeader(): void
     {
-        /** @var MockInterface|Response */
+        /** @var MockInterface&Response $response */
         $response = m::mock(Psr7Response::class);
         $response->shouldReceive('withHeader')
                  ->withArgs(['Location', 'https://example.com'])
@@ -151,7 +151,7 @@ class ResponseTest extends TestCase
 
     public function testWithAddedHeader(): void
     {
-        /** @var MockInterface|Response */
+        /** @var MockInterface&Response $response */
         $response = m::mock(Psr7Response::class);
         $response->shouldReceive('withAddedHeader')
                  ->withArgs(['Location', 'https://example.com'])
@@ -166,7 +166,7 @@ class ResponseTest extends TestCase
 
     public function testWithoutHeader(): void
     {
-        /** @var MockInterface|Response */
+        /** @var MockInterface&Response $response */
         $response = m::mock(Psr7Response::class);
         $response->shouldReceive('withoutHeader')
                  ->withArgs(['Location'])
@@ -181,10 +181,10 @@ class ResponseTest extends TestCase
 
     public function testGetBody(): void
     {
-        /** @var MockInterface|StreamInterface */
+        /** @var MockInterface&StreamInterface $body */
         $body = m::mock(StreamInterface::class);
 
-        /** @var MockInterface|Response */
+        /** @var MockInterface&Response $response */
         $response = m::mock(Psr7Response::class);
         $response->shouldReceive('getBody')
                  ->andReturn($body);
@@ -196,10 +196,10 @@ class ResponseTest extends TestCase
 
     public function testWithBody(): void
     {
-        /** @var MockInterface|StreamInterface */
+        /** @var MockInterface&StreamInterface $body */
         $body = m::mock(StreamInterface::class);
 
-        /** @var MockInterface|Response */
+        /** @var MockInterface&Response $response */
         $response = m::mock(Psr7Response::class);
         $response->shouldReceive('withBody')
                  ->withArgs([$body])

--- a/api/tests/Case/Service/Client/ResponseTest.php
+++ b/api/tests/Case/Service/Client/ResponseTest.php
@@ -23,11 +23,57 @@ class ResponseTest extends TestCase
         $actual = new Response($response);
         $actual->setTotalTime(1.0);
         $actual->setStartTransferTime(2.0);
+        $actual->setHttpVersion(null);
         $actual->setPrimaryIP('2001:db8::4545:1');
 
         $this->assertEquals(1.0, $actual->getTotalTime());
         $this->assertEquals(2.0, $actual->getStartTransferTime());
+        $this->assertEquals(null, $actual->getHttpVersion());
         $this->assertEquals('2001:db8::4545:1', $actual->getPrimaryIP());
+    }
+
+    public function testConstructHttp10(): void
+    {
+        /** @var MockInterface&Response $response */
+        $response = m::mock(Psr7Response::class);
+
+        $actual = new Response($response);
+        $actual->setHttpVersion(CURL_HTTP_VERSION_1_0);
+
+        $this->assertEquals('1.0', $actual->getHttpVersion());
+    }
+
+    public function testConstructHttp11(): void
+    {
+        /** @var MockInterface&Response $response */
+        $response = m::mock(Psr7Response::class);
+
+        $actual = new Response($response);
+        $actual->setHttpVersion(CURL_HTTP_VERSION_1_1);
+
+        $this->assertEquals('1.1', $actual->getHttpVersion());
+    }
+
+    public function testConstructHttp20(): void
+    {
+        /** @var MockInterface&Response $response */
+        $response = m::mock(Psr7Response::class);
+
+        $actual = new Response($response);
+        $actual->setHttpVersion(CURL_HTTP_VERSION_2);
+
+        $this->assertEquals('2', $actual->getHttpVersion());
+    }
+
+    public function testConstructHttp30(): void
+    {
+        /** @var MockInterface&Response $response */
+        $response = m::mock(Psr7Response::class);
+
+        $actual = new Response($response);
+        $actual->setHttpVersion(CURL_HTTP_VERSION_3);
+
+        $this->assertEquals('3', $actual->getHttpVersion());
     }
 
     public function testGetStatus(): void

--- a/api/tests/Case/Service/ClientServiceTest.php
+++ b/api/tests/Case/Service/ClientServiceTest.php
@@ -164,13 +164,13 @@ class ClientServiceTest extends TestCase
 
     public function testSend(): void
     {
-        /** @var MockInterface|RequestInterface */
+        /** @var MockInterface&RequestInterface $request */
         $request = m::mock(RequestInterface::class);
 
-        /** @var MockInterface|ResponseInterface */
+        /** @var MockInterface&ResponseInterface $response */
         $response = m::mock(ResponseInterface::class);
 
-        /** @var ClientInterface|MockInterface */
+        /** @var ClientInterface&MockInterface $client */
         $client = m::mock(ClientInterface::class);
         $client->shouldReceive('send')
                ->withArgs([$request, ['http_errors' => false]])
@@ -186,13 +186,13 @@ class ClientServiceTest extends TestCase
 
     public function testSendAsync(): void
     {
-        /** @var MockInterface|RequestInterface */
+        /** @var MockInterface&RequestInterface $request */
         $request = m::mock(RequestInterface::class);
 
-        /** @var MockInterface|PromiseInterface */
+        /** @var MockInterface&PromiseInterface $promise */
         $promise = m::mock(PromiseInterface::class);
 
-        /** @var ClientInterface|MockInterface */
+        /** @var ClientInterface&MockInterface $client */
         $client = m::mock(ClientInterface::class);
         $client->shouldReceive('sendAsync')
                ->withArgs([$request, ['http_errors' => false]])
@@ -208,10 +208,10 @@ class ClientServiceTest extends TestCase
 
     public function testRequest(): void
     {
-        /** @var MockInterface|ResponseInterface */
+        /** @var MockInterface&ResponseInterface $response */
         $response = m::mock(ResponseInterface::class);
 
-        /** @var ClientInterface|MockInterface */
+        /** @var ClientInterface&MockInterface $client */
         $client = m::mock(ClientInterface::class);
         $client->shouldReceive('request')
                ->withArgs(['GET', 'https://example.com', ['http_errors' => false]])
@@ -227,10 +227,10 @@ class ClientServiceTest extends TestCase
 
     public function testRequestAsync(): void
     {
-        /** @var MockInterface|PromiseInterface */
+        /** @var MockInterface&PromiseInterface $promise */
         $promise = m::mock(PromiseInterface::class);
 
-        /** @var ClientInterface|MockInterface */
+        /** @var ClientInterface&MockInterface $client */
         $client = m::mock(ClientInterface::class);
         $client->shouldReceive('requestAsync')
                ->withArgs(['GET', 'https://example.com', ['http_errors' => false]])
@@ -246,7 +246,7 @@ class ClientServiceTest extends TestCase
 
     public function testGetConfig(): void
     {
-        /** @var ClientInterface|MockInterface */
+        /** @var ClientInterface&MockInterface $client */
         $client = m::mock(ClientInterface::class);
         $client->shouldReceive('getConfig')
                ->andReturn(['http_errors' => false]);

--- a/api/tests/Case/Service/ClientServiceTest.php
+++ b/api/tests/Case/Service/ClientServiceTest.php
@@ -8,9 +8,11 @@ use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Middleware;
 use GuzzleHttp\Promise\PromiseInterface;
 use GuzzleHttp\Psr7\Request as Psr7Request;
 use GuzzleHttp\Psr7\Response as Psr7Response;
+use HomoChecker\Contracts\Service\CacheService;
 use HomoChecker\Contracts\Service\Client\Response;
 use HomoChecker\Service\ClientService;
 use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
@@ -35,7 +37,16 @@ class ClientServiceTest extends TestCase
             'transfer_time' => 1.0,
         ]);
 
-        $service = new ClientService($client, 5);
+        /** @var MockInterface&CacheService $cache */
+        $cache = m::mock(CacheService::class);
+        $cache->shouldReceive('loadAltsvc')
+              ->withArgs(['https://foo.example.com/1', ''])
+              ->andReturn('');
+        $cache->shouldReceive('loadAltsvc')
+              ->withArgs(['https://homo.example.com', ''])
+              ->andReturn('');
+
+        $service = new ClientService($client, $cache, 5);
         $generator = $service->getAsync('https://foo.example.com/1');
 
         $generator->rewind();
@@ -79,7 +90,16 @@ class ClientServiceTest extends TestCase
             'transfer_time' => 1.0,
         ]);
 
-        $service = new ClientService($client, 5);
+        /** @var MockInterface&CacheService $cache */
+        $cache = m::mock(CacheService::class);
+        $cache->shouldReceive('loadAltsvc')
+              ->withArgs(['https://foo.example.com/2', ''])
+              ->andReturn('');
+        $cache->shouldReceive('loadAltsvc')
+              ->withArgs(['https://foo2.example.com', ''])
+              ->andReturn('');
+
+        $service = new ClientService($client, $cache, 5);
         $generator = $service->getAsync('https://foo.example.com/2');
 
         $generator->rewind();
@@ -131,6 +151,124 @@ class ClientServiceTest extends TestCase
         $this->assertFalse($generator->valid());
     }
 
+    public function testGetAsyncWithAltsvcH2(): void
+    {
+        $container = [];
+        $handler = HandlerStack::create(new MockHandler([
+            new Psr7Response(301, [
+                'Location' => 'https://homo.example.com',
+                'Alt-Svc' => 'h2=":443"; ma=86400',
+            ], ''),
+        ]));
+        $handler->push(Middleware::history($container));
+
+        $client = new Client([
+            'allow_redirects' => false,
+            'http_errors' => false,
+            'handler' => $handler,
+            'transfer_time' => 1.0,
+        ]);
+
+        /** @var MockInterface&CacheService $cache */
+        $cache = m::mock(CacheService::class);
+        $cache->shouldReceive('loadAltsvc')
+              ->withArgs(['https://foo.example.com/1', ''])
+              ->andReturn('');
+        $cache->shouldReceive('loadAltsvc')
+              ->withArgs(['https://homo.example.com', ''])
+              ->andReturn('');
+
+        $service = new ClientService($client, $cache, 5);
+        $generator = $service->getAsync('https://foo.example.com/1');
+
+        $generator->rewind();
+        $this->assertTrue($generator->valid());
+
+        // (1/2) https://foo.example.com/1
+        /** @var string $actual */
+        $actual = $generator->key();
+        $this->assertEquals('https://foo.example.com/1', $actual);
+
+        /** @var PromiseInterface<Response> $actual */
+        $actual = $generator->current();
+        $this->assertInstanceOf(PromiseInterface::class, $actual);
+
+        $actual = $actual->wait();
+        $this->assertArrayNotHasKey('curl', $container[0]['options']);
+
+        /** @var Response $actual */
+        $this->assertInstanceOf(Response::class, $actual);
+        $this->assertEquals('https://homo.example.com', $actual->getHeaderLine('Location'));
+        $this->assertEquals(301, $actual->getStatusCode());
+        $this->assertEquals(1.0, $actual->getTotalTime());
+        $this->assertEquals(0.0, $actual->getStartTransferTime());
+        $this->assertNull($actual->getHttpVersion());
+        $this->assertNull($actual->getPrimaryIP());
+
+        $generator->next();
+        $this->assertTrue($generator->valid());
+    }
+
+    public function testGetAsyncWithAltsvcH3(): void
+    {
+        $container = [];
+        $handler = HandlerStack::create(new MockHandler([
+            new Psr7Response(301, [
+                'Location' => 'https://homo.example.com',
+                'Alt-Svc' => 'h3=":443"; ma=86400, h3-29=":443"; ma=86400, h3-28=":443"; ma=86400, h3-27=":443"; ma=86400',
+            ], ''),
+        ]));
+        $handler->push(Middleware::history($container));
+
+        $client = new Client([
+            'allow_redirects' => false,
+            'http_errors' => false,
+            'handler' => $handler,
+            'transfer_time' => 1.0,
+        ]);
+
+        /** @var MockInterface&CacheService $cache */
+        $cache = m::mock(CacheService::class);
+        $cache->shouldReceive('loadAltsvc')
+              ->withArgs(['https://foo.example.com/1', ''])
+              ->andReturn('h3');
+        $cache->shouldReceive('loadAltsvc')
+              ->withArgs(['https://homo.example.com', ''])
+              ->andReturn('h3');
+        $cache->shouldReceive('saveAltsvc')
+              ->withArgs(['https://foo.example.com/1', 'h3', 86400]);
+
+        $service = new ClientService($client, $cache, 5);
+        $generator = $service->getAsync('https://foo.example.com/1');
+
+        $generator->rewind();
+        $this->assertTrue($generator->valid());
+
+        // (1/2) https://foo.example.com/1
+        /** @var string $actual */
+        $actual = $generator->key();
+        $this->assertEquals('https://foo.example.com/1', $actual);
+
+        /** @var PromiseInterface<Response> $actual */
+        $actual = $generator->current();
+        $this->assertInstanceOf(PromiseInterface::class, $actual);
+
+        $actual = $actual->wait();
+        $this->assertEquals(CURL_HTTP_VERSION_3, $container[0]['options']['curl'][CURLOPT_HTTP_VERSION]);
+
+        /** @var Response $actual */
+        $this->assertInstanceOf(Response::class, $actual);
+        $this->assertEquals('https://homo.example.com', $actual->getHeaderLine('Location'));
+        $this->assertEquals(301, $actual->getStatusCode());
+        $this->assertEquals(1.0, $actual->getTotalTime());
+        $this->assertEquals(0.0, $actual->getStartTransferTime());
+        $this->assertNull($actual->getHttpVersion());
+        $this->assertNull($actual->getPrimaryIP());
+
+        $generator->next();
+        $this->assertTrue($generator->valid());
+    }
+
     public function testGetAsyncWithException(): void
     {
         $client = new Client([
@@ -142,7 +280,13 @@ class ClientServiceTest extends TestCase
             'transfer_time' => 1.0,
         ]);
 
-        $service = new ClientService($client, 5);
+        /** @var MockInterface&CacheService $cache */
+        $cache = m::mock(CacheService::class);
+        $cache->shouldReceive('loadAltsvc')
+              ->withArgs(['https://baz.example.com', ''])
+              ->andReturn('');
+
+        $service = new ClientService($client, $cache, 5);
         $generator = $service->getAsync('https://baz.example.com');
 
         $generator->rewind();
@@ -176,7 +320,10 @@ class ClientServiceTest extends TestCase
                ->withArgs([$request, ['http_errors' => false]])
                ->andReturn($response);
 
-        $service = new ClientService($client, 5);
+        /** @var MockInterface&CacheService $cache */
+        $cache = m::mock(CacheService::class);
+
+        $service = new ClientService($client, $cache, 5);
         $actual = $service->send($request, [
             'http_errors' => false,
         ]);
@@ -198,7 +345,10 @@ class ClientServiceTest extends TestCase
                ->withArgs([$request, ['http_errors' => false]])
                ->andReturn($promise);
 
-        $service = new ClientService($client, 5);
+        /** @var MockInterface&CacheService $cache */
+        $cache = m::mock(CacheService::class);
+
+        $service = new ClientService($client, $cache, 5);
         $actual = $service->sendAsync($request, [
             'http_errors' => false,
         ]);
@@ -217,7 +367,10 @@ class ClientServiceTest extends TestCase
                ->withArgs(['GET', 'https://example.com', ['http_errors' => false]])
                ->andReturn($response);
 
-        $service = new ClientService($client, 5);
+        /** @var MockInterface&CacheService $cache */
+        $cache = m::mock(CacheService::class);
+
+        $service = new ClientService($client, $cache, 5);
         $actual = $service->request('GET', 'https://example.com', [
             'http_errors' => false,
         ]);
@@ -236,7 +389,10 @@ class ClientServiceTest extends TestCase
                ->withArgs(['GET', 'https://example.com', ['http_errors' => false]])
                ->andReturn($promise);
 
-        $service = new ClientService($client, 5);
+        /** @var MockInterface&CacheService $cache */
+        $cache = m::mock(CacheService::class);
+
+        $service = new ClientService($client, $cache, 5);
         $actual = $service->requestAsync('GET', 'https://example.com', [
             'http_errors' => false,
         ]);
@@ -251,7 +407,10 @@ class ClientServiceTest extends TestCase
         $client->shouldReceive('getConfig')
                ->andReturn(['http_errors' => false]);
 
-        $service = new ClientService($client, 5);
+        /** @var MockInterface&CacheService $cache */
+        $cache = m::mock(CacheService::class);
+
+        $service = new ClientService($client, $cache, 5);
         $actual = $service->getConfig();
 
         $this->assertEquals(['http_errors' => false], $actual);

--- a/api/tests/Case/Service/HomoServiceTest.php
+++ b/api/tests/Case/Service/HomoServiceTest.php
@@ -40,7 +40,7 @@ class HomoServiceTest extends TestCase
 
     public function testCountAll(): void
     {
-        /** @var HomoRepository|MockInterface $repository */
+        /** @var HomoRepository&MockInterface $repository */
         $repository = m::mock(HomoRepository::class);
         $repository->shouldReceive('count')
                    ->andReturn(3);
@@ -54,7 +54,7 @@ class HomoServiceTest extends TestCase
     {
         $screen_name = 'foo';
 
-        /** @var HomoRepository|MockInterface $repository */
+        /** @var HomoRepository&MockInterface $repository */
         $repository = m::mock(HomoRepository::class);
         $repository->shouldReceive('countByScreenName')
                    ->with($screen_name)
@@ -67,7 +67,7 @@ class HomoServiceTest extends TestCase
 
     public function testFindAll(): void
     {
-        /** @var HomoRepository|MockInterface $repository */
+        /** @var HomoRepository&MockInterface $repository */
         $repository = m::mock(HomoRepository::class);
         $repository->shouldReceive('findAll')
                    ->andReturn($this->users);
@@ -81,7 +81,7 @@ class HomoServiceTest extends TestCase
     {
         $screen_name = 'foo';
 
-        /** @var HomoRepository|MockInterface $repository */
+        /** @var HomoRepository&MockInterface $repository */
         $repository = m::mock(HomoRepository::class);
         $repository->shouldReceive('findByScreenName')
                    ->with($screen_name)
@@ -100,7 +100,7 @@ class HomoServiceTest extends TestCase
         insert into `users` (`screen_name`, `service`, `url`) values ('bar', 'twitter', 'https://bar.example.com');
         SQL;
 
-        /** @var HomoRepository|MockInterface $repository */
+        /** @var HomoRepository&MockInterface $repository */
         $repository = m::mock(HomoRepository::class);
         $repository->shouldReceive('export')
                    ->andReturn($sql);

--- a/api/tests/Case/Service/Profile/MastodonProfileServiceTest.php
+++ b/api/tests/Case/Service/Profile/MastodonProfileServiceTest.php
@@ -48,7 +48,7 @@ class MastodonProfileServiceTest extends TestCase
 
         $client = new Client(compact('handler'));
 
-        /** @var CacheService|MockInterface $cache */
+        /** @var CacheService&MockInterface $cache */
         $cache = m::mock(CacheService::class);
         $cache->shouldReceive('loadIconMastodon')
               ->andReturn(null);
@@ -56,7 +56,7 @@ class MastodonProfileServiceTest extends TestCase
         $cache->shouldReceive('saveIconMastodon')
               ->with($screen_name, $url, m::any());
 
-        /** @var Counter|MockInterface $profileErrorCounter */
+        /** @var Counter&MockInterface $profileErrorCounter */
         $profileErrorCounter = m::mock(Counter::class);
         $profileErrorCounter->shouldReceive('inc')
                             ->withArgs([
@@ -88,15 +88,15 @@ class MastodonProfileServiceTest extends TestCase
         $url = 'https://files.mastodon.social/accounts/avatars/000/000/001/original/114514.png';
         $screen_name = '@example@mastodon.social';
 
-        /** @var ClientInterface|MockInterface $client */
+        /** @var ClientInterface&MockInterface $client */
         $client = m::mock(ClientInterface::class);
 
-        /** @var CacheService|MockInterface $cache */
+        /** @var CacheService&MockInterface $cache */
         $cache = m::mock(CacheService::class);
         $cache->shouldReceive('loadIconMastodon')
               ->andReturn($url);
 
-        /** @var Counter|MockInterface $profileErrorCounter */
+        /** @var Counter&MockInterface $profileErrorCounter */
         $profileErrorCounter = m::mock(Counter::class);
 
         $profile = new MastodonProfileService($client, $cache, $profileErrorCounter);
@@ -108,13 +108,13 @@ class MastodonProfileServiceTest extends TestCase
      */
     public function testParseScreenName($screen_name, $username, $instance): void
     {
-        /** @var ClientInterface|MockInterface $client */
+        /** @var ClientInterface&MockInterface $client */
         $client = m::mock(ClientInterface::class);
 
-        /** @var CacheService|MockInterface $cache */
+        /** @var CacheService&MockInterface $cache */
         $cache = m::mock(CacheService::class);
 
-        /** @var Counter|MockInterface $profileErrorCounter */
+        /** @var Counter&MockInterface $profileErrorCounter */
         $profileErrorCounter = m::mock(Counter::class);
 
         $profile = new MastodonProfileService($client, $cache, $profileErrorCounter);
@@ -130,13 +130,13 @@ class MastodonProfileServiceTest extends TestCase
     {
         $this->expectException(\RuntimeException::class);
 
-        /** @var ClientInterface|MockInterface $client */
+        /** @var ClientInterface&MockInterface $client */
         $client = m::mock(ClientInterface::class);
 
-        /** @var CacheService|MockInterface $cache */
+        /** @var CacheService&MockInterface $cache */
         $cache = m::mock(CacheService::class);
 
-        /** @var Counter|MockInterface $profileErrorCounter */
+        /** @var Counter&MockInterface $profileErrorCounter */
         $profileErrorCounter = m::mock(Counter::class);
 
         $profile = new MastodonProfileService($client, $cache, $profileErrorCounter);

--- a/api/tests/Case/Service/Profile/TwitterProfileServiceTest.php
+++ b/api/tests/Case/Service/Profile/TwitterProfileServiceTest.php
@@ -49,10 +49,10 @@ class TwitterProfileServiceTest extends TestCase
             new RequestException('Connection problem occurred', new Request('GET', '')),
         ]));
 
-        /** @var ClientInterface|MockInterface $client */
+        /** @var ClientInterface&MockInterface $client */
         $client = new Client(compact('handler'));
 
-        /** @var CacheService|MockInterface $cache */
+        /** @var CacheService&MockInterface $cache */
         $cache = m::mock(CacheService::class);
         $cache->shouldReceive('loadIconTwitter')
               ->andReturn(null);
@@ -60,7 +60,7 @@ class TwitterProfileServiceTest extends TestCase
         $cache->shouldReceive('saveIconTwitter')
               ->with($screen_name, $url, m::any());
 
-        /** @var Counter|MockInterface $profileErrorCounter */
+        /** @var Counter&MockInterface $profileErrorCounter */
         $profileErrorCounter = m::mock(Counter::class);
         $profileErrorCounter->shouldReceive('inc')
                             ->withArgs([
@@ -82,15 +82,15 @@ class TwitterProfileServiceTest extends TestCase
         $url = 'https://pbs.twimg.com/profile_images/114514/example_bigger.jpg';
         $screen_name = 'example';
 
-        /** @var ClientInterface|MockInterface $client */
+        /** @var ClientInterface&MockInterface $client */
         $client = m::mock(ClientInterface::class);
 
-        /** @var CacheService|MockInterface $cache */
+        /** @var CacheService&MockInterface $cache */
         $cache = m::mock(CacheService::class);
         $cache->shouldReceive('loadIconTwitter')
               ->andReturn($url);
 
-        /** @var Counter|MockInterface $profileErrorCounter */
+        /** @var Counter&MockInterface $profileErrorCounter */
         $profileErrorCounter = m::mock(Counter::class);
 
         $profile = new TwitterProfileService($client, $cache, $profileErrorCounter);

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,6 @@ services:
       target: dev
     working_dir: /var/www/html/api
     environment:
-      HOMOCHECKER_ALTSVC_CACHE: /tmp/altsvc-cache.txt
       HOMOCHECKER_DB_HOST: database
       HOMOCHECKER_DB_USERNAME: homo
       HOMOCHECKER_DB_PASSWORD: homo


### PR DESCRIPTION
Currently `CURLOPT_ALTSVC` suddenly consumes a lot of RAM (~1.5 GiB) and makes an entire VM unresponsive. This PR handles Alt-Svc entries to be manually cached inside Redis.