### PR TITLE
Use unique bind mount caches between Docker images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,18 @@
 # syntax = docker/dockerfile:experimental
 FROM node:17.1.0-slim AS dependencies
 WORKDIR /usr/src/client
-RUN --mount=type=cache,target=/var/cache/apt \
-    --mount=type=cache,target=/var/lib/apt/lists \
+RUN --mount=type=cache,id=client:/var/cache/apt,target=/var/cache/apt \
+    --mount=type=cache,id=client:/var/lib/apt/lists,target=/var/lib/apt/lists \
     apt-get -y update && \
     apt-get -y install \
         git
 COPY client/package.json client/yarn.lock /usr/src/client/
 RUN --mount=type=tmpfs,target=/tmp \
-    --mount=type=cache,target=/usr/local/share/.cache/yarn \
+    --mount=type=cache,id=client:/usr/local/share/.cache/yarn,target=/usr/local/share/.cache/yarn \
     yarn
 
 FROM dependencies AS dev
-RUN --mount=type=cache,target=/mnt/yarn,id=/usr/local/share/.cache/yarn \
+RUN --mount=type=cache,id=client:/usr/local/share/.cache/yarn,target=/mnt/yarn \
     cp -r /mnt/yarn /usr/local/share/.cache/
 
 FROM dependencies AS build

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,7 +1,7 @@
 # syntax = docker/dockerfile:experimental
 FROM debian:bullseye-slim AS build-dependencies
-RUN --mount=type=cache,target=/var/cache/apt \
-    --mount=type=cache,target=/var/lib/apt/lists \
+RUN --mount=type=cache,id=api:/var/cache/apt,target=/var/cache/apt \
+    --mount=type=cache,id=api:/var/lib/apt/lists,target=/var/lib/apt/lists \
     apt-get -y update && \
     apt-get -y install \
         autoconf \
@@ -60,8 +60,8 @@ COPY --from=curl /usr/local/bin/curl-config /usr/local/bin/
 COPY --from=curl /usr/local/lib/ /usr/local/lib/
 RUN docker-php-source extract
 COPY php/ /usr/src/php/
-RUN --mount=type=cache,target=/var/cache/apt \
-    --mount=type=cache,target=/var/lib/apt/lists \
+RUN --mount=type=cache,id=api:/var/cache/apt,target=/var/cache/apt \
+    --mount=type=cache,id=api:/var/lib/apt/lists,target=/var/lib/apt/lists \
     apt-get -y update && \
     apt-get -y install \
         libargon2-dev \
@@ -126,22 +126,22 @@ RUN --mount=type=cache,target=/var/cache/apt \
 
 FROM runtime AS dependencies
 COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
-RUN --mount=type=cache,target=/var/cache/apt \
-    --mount=type=cache,target=/var/lib/apt/lists \
+RUN --mount=type=cache,id=api:/var/cache/apt,target=/var/cache/apt \
+    --mount=type=cache,id=api:/var/lib/apt/lists,target=/var/lib/apt/lists \
     apt-get -y update && \
     apt-get -y install \
         git \
         unzip
 COPY composer.json composer.lock /var/www/html/api/
-RUN --mount=type=cache,target=/root/.composer \
+RUN --mount=type=cache,id=api:/root/.composer,target=/root/.composer \
     composer install --no-dev --no-progress --no-scripts --no-autoloader && \
     composer dump-autoload --no-dev --no-scripts --optimize
 
 FROM dependencies AS dev
-RUN --mount=type=cache,target=/root/.composer \
+RUN --mount=type=cache,id=api:/root/.composer,target=/root/.composer \
     composer install --no-progress --no-scripts && \
     composer dump-autoload --no-scripts --optimize
-RUN --mount=type=cache,target=/mnt/.composer,id=/root/.composer \
+RUN --mount=type=cache,id=api:/root/.composer,target=/mnt/.composer \
     cp -r /mnt/.composer /root/
 
 FROM scratch


### PR DESCRIPTION
Currently, the bind mounts with the same name share the same volume for cache, but it often prevented the images to be built in parallel since it broke the lock. Now parallel builds will no longer fail due to the following error:
```
Reading package lists...
E: Could not get lock /var/lib/apt/lists/lock. It is held by process 0
E: Unable to lock directory /var/lib/apt/lists/
```