### PR TITLE
Fix database persistence in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -67,7 +67,7 @@ services:
         read_only: true
       - type: volume
         source: database
-        target: /var/lib/postgres/data
+        target: /var/lib/postgresql/data
     networks:
       - default
 


### PR DESCRIPTION
Every time a database container is recreated, another anonymous volume gets created with the current configuration. This PR aligns bind mount to point to the correct location where `postgres` image specifies.