### PR TITLE
Fix shared libraries not being copied to production image

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -170,6 +170,7 @@ COPY --from=runtime /tmp/ /tmp/
 COPY --from=runtime /usr/lib/ /usr/lib/
 COPY --from=runtime /usr/local/etc/ /usr/local/etc/
 COPY --from=runtime /usr/local/lib/ /usr/local/lib/
+COPY --from=runtime /usr/local/lib64/ /usr/local/lib64/
 COPY --from=runtime /usr/local/sbin/php-fpm /usr/local/sbin/
 COPY --from=runtime /usr/share/ca-certificates/ /usr/share/ca-certificates/
 COPY --from=dependencies /var/www/html/api /var/www/html/api


### PR DESCRIPTION
The production image has been broken as shared libraries that have appeared in `/usr/local/lib64` since #2236 didn't get copied, causing the following error. This PR copies them to solve this issue.
```
/usr/local/sbin/php-fpm: error while loading shared libraries: libssl.so.81.3: cannot open shared object file: No such file or directory
```