### PR TITLE
Remove default IPv6-aware configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ client/node_modules
 
 
 ### Project Files ###
+compose.override.yaml
 api/build
 client/dist
 client/fonts/*

--- a/README.md
+++ b/README.md
@@ -128,12 +128,6 @@ $ export HOMOCHECKER_ENV=production
 $ export HOMOCHECKER_PORT=4545
 ```
 
-IPv6 接続を有効にするためには、あらかじめサブネットを指定してネットワークを作成しておく必要があります。
-
-```sh
-$ docker network create --attachable --ipv6 --subnet=fd00:4545::/48 homochecker_ipv6
-```
-
 ### 実行
 
 ```sh

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -125,8 +125,7 @@ RUN --mount=type=cache,id=api:/var/cache/apt,target=/var/cache/apt \
     docker-php-source delete && \
     rm -rf /tmp/* && \
     echo 'display_errors = 0' > /usr/local/etc/php/conf.d/overrides.ini && \
-    sed -i 's/^access\.log/; \0/' /usr/local/etc/php-fpm.d/docker.conf && \
-    echo 'label ::1/128 0' > /etc/gai.conf
+    sed -i '/^access\.log/d' /usr/local/etc/php-fpm.d/docker.conf
 
 FROM runtime AS dependencies
 COPY --from=composer:2.4.4 /usr/bin/composer /usr/bin/composer
@@ -159,7 +158,6 @@ RUN pecl install pcov && \
 
 FROM scratch
 COPY src /var/www/html/api/src
-COPY --from=runtime /etc/gai.conf /etc/
 COPY --from=runtime /etc/group /etc/
 COPY --from=runtime /etc/ld.so.cache /etc/
 COPY --from=runtime /etc/passwd /etc/

--- a/compose.yaml
+++ b/compose.yaml
@@ -17,9 +17,6 @@ services:
       - type: bind
         source: ./api
         target: /var/www/html/api
-    networks:
-      - default
-      - ipv6
 
   build:
     build:
@@ -49,8 +46,6 @@ services:
         source: ./client/conf
         target: /etc/nginx/templates
         read_only: true
-    networks:
-      - default
 
   database:
     image: postgres:15.2
@@ -66,12 +61,7 @@ services:
       - type: volume
         source: database
         target: /var/lib/postgresql/data
-    networks:
-      - default
 
 volumes:
   database:
     driver: local
-
-networks:
-  ipv6:


### PR DESCRIPTION
This PR removes IPv6-aware configurations from docker compose and Dockerfile.

For development, it is still possible to create a `compose.override.yaml` like the following:
```yaml
services:
  api:
    volumes:
      - type: bind
        source: ./api/gai.conf
        target: /etc/gai.conf

networks:
  default:
    enable_ipv6: true
    ipam:
      driver: default
      config:
        - subnet: fd00:4545::/48
```
and create a `gai.conf` like:
```
label ::1/128 0
```

For production, it depends on to which infrastructure HomoChecker is deployed; however, container orchestrators should support bind mounts that enable more flexible overwrites.