### PR TITLE
Fix incompatibility with Mastodon in GET /actor

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ $ export HOMOCHECKER_API_HOST=api
 
 ```sh
 $ export HOMOCHECKER_AP_ACTOR_ID=https://example.com/actor
+$ export HOMOCHECKER_AP_ACTOR_PREFERRED_USERNAME=example.com
 $ export HOMOCHECKER_AP_ACTOR_PUBLIC_KEY=/path/to/public_key
 $ export HOMOCHECKER_DB_HOST=database
 $ export HOMOCHECKER_DB_PORT=5432

--- a/api/src/Providers/HomoProvider.php
+++ b/api/src/Providers/HomoProvider.php
@@ -78,6 +78,9 @@ class HomoProvider extends ServiceProvider
             ->needs('$id')
             ->give(fn (Container $app) => $app->make('config')->get('activityPub.actor')['id']);
         $this->app->when(ActivityPubService::class)
+            ->needs('$preferredUsername')
+            ->give(fn (Container $app) => $app->make('config')->get('activityPub.actor')['preferred_username']);
+        $this->app->when(ActivityPubService::class)
             ->needs('$publicKeyPem')
             ->give(function (Container $app) {
                 $actor = $app->make('config')->get('activityPub.actor');

--- a/api/src/Service/ActivityPubService.php
+++ b/api/src/Service/ActivityPubService.php
@@ -9,6 +9,7 @@ class ActivityPubService implements ActivityPubServiceContract
 {
     public function __construct(
         protected string $id,
+        protected string $preferredUsername,
         protected string $publicKeyPem,
     ) {}
 
@@ -24,6 +25,7 @@ class ActivityPubService implements ActivityPubServiceContract
             ],
             'id' => $this->id,
             'type' => 'Application',
+            'preferredUsername' => $this->preferredUsername,
             'publicKey' => [
                 'id' => $this->id . '#main-key',
                 'owner' => $this->id,

--- a/api/src/config.php
+++ b/api/src/config.php
@@ -42,6 +42,7 @@ return [
     ],
     'activityPub.actor' => [
         'id' => env('HOMOCHECKER_AP_ACTOR_ID'),
+        'preferred_username' => env('HOMOCHECKER_AP_ACTOR_PREFERRED_USERNAME'),
         'public_key' => env('HOMOCHECKER_AP_ACTOR_PUBLIC_KEY'),
     ],
     'client' => [

--- a/api/tests/Case/Action/ActivityPubActorActionTest.php
+++ b/api/tests/Case/Action/ActivityPubActorActionTest.php
@@ -33,6 +33,7 @@ class ActivityPubActorActionTest extends TestCase
                         ],
                         'id' => 'https://example.com/actor',
                         'type' => 'Application',
+                        'preferredUsername' => 'example.com',
                         'publicKey' => [
                             'id' => 'https://example.com/actor#main-key',
                             'owner' => 'https://example.com/actor',
@@ -54,6 +55,7 @@ class ActivityPubActorActionTest extends TestCase
             ],
             'id' => 'https://example.com/actor',
             'type' => 'Application',
+            'preferredUsername' => 'example.com',
             'publicKey' => [
                 'id' => 'https://example.com/actor#main-key',
                 'owner' => 'https://example.com/actor',

--- a/api/tests/Case/Service/ActivityPubServiceTest.php
+++ b/api/tests/Case/Service/ActivityPubServiceTest.php
@@ -9,6 +9,7 @@ use PHPUnit\Framework\TestCase;
 class ActivityPubServiceTest extends TestCase
 {
     protected string $id;
+    protected string $preferredUsername;
     protected string $publicKeyPem;
 
     public function setUp(): void
@@ -16,12 +17,13 @@ class ActivityPubServiceTest extends TestCase
         parent::setUp();
 
         $this->id = 'https://example.com/actor';
+        $this->preferredUsername = 'example.com';
         $this->publicKeyPem = "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAUVd1lBkQ8I/3PJIRLgXbm2TDv16wQBXuN09wWo8lh74=\n-----END PUBLIC KEY-----\n";
     }
 
     public function testActor(): void
     {
-        $activityPub = new ActivityPubService($this->id, $this->publicKeyPem);
+        $activityPub = new ActivityPubService($this->id, $this->preferredUsername, $this->publicKeyPem);
 
         $expected = [
             '@context' => [
@@ -30,6 +32,7 @@ class ActivityPubServiceTest extends TestCase
             ],
             'id' => 'https://example.com/actor',
             'type' => 'Application',
+            'preferredUsername' => 'example.com',
             'publicKey' => [
                 'id' => 'https://example.com/actor#main-key',
                 'owner' => 'https://example.com/actor',

--- a/bin/init
+++ b/bin/init
@@ -10,6 +10,6 @@ if [[ ! -f api/activity_pub_actor.key ]]; then
         exit 1
     fi
 
-    openssl genpkey -algorithm ed25519 -out api/activity_pub_actor.key
+    openssl genpkey -quiet -algorithm rsa -pkeyopt rsa_keygen_bits:2048 -out api/activity_pub_actor.key
     openssl pkey -in api/activity_pub_actor.key -pubout -out api/activity_pub_actor.pub
 fi

--- a/compose.yaml
+++ b/compose.yaml
@@ -6,6 +6,7 @@ services:
     working_dir: /var/www/html/api
     environment:
       HOMOCHECKER_AP_ACTOR_ID: http://localhost:4545/actor
+      HOMOCHECKER_AP_ACTOR_PREFERRED_USERNAME: localhost:4545
       HOMOCHECKER_AP_ACTOR_PUBLIC_KEY: /activity_pub_actor_public_key
       HOMOCHECKER_DB_HOST: database
       HOMOCHECKER_DB_USERNAME: homo


### PR DESCRIPTION
This PR fixes the following error which the current implementation ends up with:
```json
{"error":"Actor https://homo.chitoku.jp:4545/actor has no 'preferredUsername', which is a requirement for Mastodon compatibility"}
```