### PR TITLE
Bump openssl from openssl-3.1.6-quic1 to openssl-3.1.7-quic1 in /api

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -12,7 +12,7 @@ RUN --mount=type=cache,id=api:/var/cache/apt,target=/var/cache/apt \
         pkg-config
 
 FROM build-dependencies AS openssl
-ARG OPENSSL_VERSION=openssl-3.1.6-quic1
+ARG OPENSSL_VERSION=openssl-3.1.7-quic1
 RUN git clone --depth=1 --recurse-submodules -b $OPENSSL_VERSION https://github.com/quictls/openssl && \
     cd openssl && \
     ./config enable-tls1_3 && \


### PR DESCRIPTION
Bumps openssl from openssl-3.1.6-quic1 to openssl-3.1.7-quic1.