### PR TITLE
Bump openssl from openssl-3.3.2 to openssl-3.4.0 in /api

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -12,7 +12,7 @@ RUN --mount=type=cache,id=api:/var/cache/apt,target=/var/cache/apt \
         pkg-config
 
 FROM build-dependencies AS openssl
-ARG OPENSSL_VERSION=openssl-3.3.2
+ARG OPENSSL_VERSION=openssl-3.4.0
 RUN git clone --depth=1 --recurse-submodules -b $OPENSSL_VERSION https://github.com/openssl/openssl && \
     cd openssl && \
     ./config enable-tls1_3 && \


### PR DESCRIPTION
Bumps openssl from openssl-3.3.2 to openssl-3.4.0.