### PR TITLE
Bump php from 8.3.13-fpm to 8.3.14-fpm in /api

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -39,7 +39,7 @@ RUN git clone --depth=1 -b $CURL_VERSION https://github.com/curl/curl && \
     make -j $(nproc) && \
     make install
 
-FROM php:8.3.13-fpm AS runtime
+FROM php:8.3.14-fpm AS runtime
 WORKDIR /var/www/html/api
 COPY --from=openssl /usr/local/bin/ /usr/local/bin/
 COPY --from=openssl /usr/local/include/ /usr/local/include/


### PR DESCRIPTION
This PR bumps php to 8.3.14 because #2736 cannot be merged as phpcov does not currently support php 8.4-fpm at this moment.