### PR TITLE
Publish `latest` images on push to master branch

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -35,12 +35,12 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push
         uses: docker/bake-action@v6
-        env:
-          TAG: ${{ github.ref_name }}
         with:
           files: docker-bake.hcl
           push: true
           set: |
+            api.tags=ghcr.io/chitoku-k/homochecker/api:${{ github.ref_name }}
+            web.tags=ghcr.io/chitoku-k/homochecker/web:${{ github.ref_name }}
             *.args.BUILDKIT_CONTEXT_KEEP_GIT_DIR=1
             *.cache-from=type=gha
             *.cache-to=type=gha,mode=max

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,11 +104,21 @@ jobs:
         uses: actions/checkout@v4
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+      - name: Log into Container Registry
+        if: ${{ github.ref_name == 'master' }}
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build
         uses: docker/bake-action@v6
         with:
           files: docker-bake.hcl
+          push: ${{ github.ref_name == 'master' }}
           set: |
+            api.tags=ghcr.io/chitoku-k/homochecker/api:latest
+            web.tags=ghcr.io/chitoku-k/homochecker/web:latest
             *.args.BUILDKIT_CONTEXT_KEEP_GIT_DIR=1
             *.cache-from=type=gha
             *.cache-to=type=gha,mode=max

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -1,23 +1,11 @@
-variable "TAG" {
-    default = "latest"
-}
-
 group "default" {
     targets = ["api", "web"]
 }
 
 target "api" {
     context = "./api"
-    tags = [
-        "ghcr.io/chitoku-k/homochecker/api:latest",
-        "ghcr.io/chitoku-k/homochecker/api:${TAG}",
-    ]
 }
 
 target "web" {
     context = "."
-    tags = [
-        "ghcr.io/chitoku-k/homochecker/web:latest",
-        "ghcr.io/chitoku-k/homochecker/web:${TAG}",
-    ]
 }


### PR DESCRIPTION
This PR changes CI/CD to publish `latest` images on push to master branch. The `latest` tag is no longer stable.