### PR TITLE
Fix OS image for php in /api

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -39,7 +39,7 @@ RUN git clone --depth=1 -b $CURL_VERSION https://github.com/curl/curl && \
     make -j $(nproc) && \
     make install
 
-FROM php:8.4.11-fpm AS runtime
+FROM php:8.4.11-fpm-bookworm AS runtime
 WORKDIR /var/www/html/api
 COPY --from=openssl /usr/local/bin/ /usr/local/bin/
 COPY --from=openssl /usr/local/include/ /usr/local/include/


### PR DESCRIPTION
This PR fixes OS image for php to always match with the one in `build-dependencies`.