### PR TITLE
Fix a bug where fontawesome was not rendered due to BOM not stripped since postcss 8.5.24

### DIFF
--- a/web/webpack.config.mjs
+++ b/web/webpack.config.mjs
@@ -37,7 +37,14 @@ export default {
                 use: [
                     { loader: "style-loader" },
                     { loader: "css-loader" },
-                    { loader: "sass-loader" },
+                    {
+                        loader: "sass-loader",
+                        options: {
+                            sassOptions: {
+                                charset: false,
+                            },
+                        },
+                    },
                 ],
             },
             {


### PR DESCRIPTION
Follows up for #3351.